### PR TITLE
Introduction post for product blog

### DIFF
--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -1,0 +1,31 @@
+[18F](https://18f.gsa.gov) has created a delivery team to implement part of the [Open Government National Action Plan](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf)'s commitment to modernizing the Freedom of Information Act.
+
+We are tasked with bringing technology to bear on this problem. We are *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
+
+
+## Where we are
+
+18F works in the open, and so you can follow our work and project discussions on GitHub, centered at [18F's `foia` repository](https://github.com/18f/foia). You can use GitHub's "Watch" feature to be notified of ongoing discussion in that repository. We'll be trying to do as much project deliberation and stakeholder interaction as possible in GitHub.
+
+Over time, the work will likely expand to include multiple repositories tackling more specific elements of the work, but our project-level discussions will remain at [`18f/foia`](https://github.com/18f/foia). So if you want to keep in close touch with the project, that's where to do it.
+
+In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the delivery team will write about our goals, plans, and progress. Compared to GitHub, updates will be less frequent and more narrative, but this is a **development blog** and so it will frequently be "in the weeds" and technical. You can use [our RSS feed](http://18f.github.io/foia/feed/) to follow our updates.
+
+
+## Our plan
+
+Our team's plan is to **reduce friction** for requestors and agencies in the FOIA process, **absorb the entropy** of petitioning a federated government of autonomous agencies, and **create a clear path** for the release of public records.
+
+To this end, we're developing, or looking at developing:
+
+* A **consolidated FOIA portal** for requestors. A central, user-facing front-end from which anyone can initiate a FOIA request to an agency in the federal government.
+* A **working API and spec** for agencies to receive FOIA requests and resolve them. In other words, a common way for our portal to cleanly interoperate with an agency's existing or new FOIA processing systems -- at least at the very beginning and end of the process.
+* An interface for **discovering public records** released through FOIA. At the very least, this means a public read API.
+* A lightweight **application for FOIA offices** to track and process requests. It would use the same interoperable request and response API as described above.
+* Tools to help agencies with **efficient preparing of records** for release. In particular, tools to make responsive documents accessible could increase the quality and quantity of publicly released documents &mdash; and be broadly useful in the federal government beyond FOIA.
+
+That's a lot of stuff. We most likely will not end up choosing (or being able) to pursue each of them to completion.
+
+What we think is that these are the areas that have the highest return on investment in using technology to modernize how the Freedom of Information Act functions in the United States.
+
+And **we welcome your help!** 18F is an [open source team](#) working in the public domain, and if you'd like to be a part of that: here we are.

--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -1,9 +1,8 @@
 ## FOIA and Technology: a development blog
 
-Welcome! We're the team created by [18F](https://18f.gsa.gov) to implement part of the U.S. Government's [commitment](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf) to modernize the Freedom of Information Act.
+Welcome! We're a team at [18F](https://18f.gsa.gov) that's implementing part of the U.S. Government's [commitment](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf) to modernize the Freedom of Information Act. This commitment was made in late 2013, and we're starting work now on the implementation. We'll be writing here about the work and challenges along the way.
 
-We're tasked with bringing technology to bear on this problem. We're *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
-
+Our team is tasked with bringing technology to bear on this problem. We're *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
 
 ### Where we are
 
@@ -11,7 +10,7 @@ We're tasked with bringing technology to bear on this problem. We're *not tasked
 
 Over time, the work will likely expand to include multiple repositories tackling more specific elements of the work, but our project-level discussions will remain at [`18f/foia`](https://github.com/18f/foia). So if you want to keep in close touch with the project, that's where to do it.
 
-In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the delivery team will write about our goals, plans, and progress. Compared to GitHub, updates will be less frequent and more narrative, but this is a **development blog** and so it will frequently be "in the weeds" and technical. You can use [our RSS feed](http://18f.github.io/foia/feed/) to follow our updates.
+In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the development team will write about our goals, plans, and progress. Compared to GitHub, updates will be less frequent and more narrative, but this is a **development blog** and so it will frequently be "in the weeds" and technical. You can use [our RSS feed](http://18f.github.io/foia/feed/) to follow our updates.
 
 
 ### Our plan
@@ -26,8 +25,6 @@ To this end, we're developing, or looking at developing:
 * A lightweight **application for FOIA offices** to track and process requests. It would use the same interoperable request and response API as described above.
 * Tools to help agencies **efficiently prepare records ** for release. In particular, tools to make responsive documents accessible could increase the quality and quantity of publicly released documents &mdash; and be broadly useful in the federal government beyond FOIA.
 
-That's a lot of stuff. We most likely won't end up choosing (or being able) to work on or finish all of them.
+That's a lot of stuff. We most likely won't end up choosing (or being able) to work on or finish all of them. But we think these are the areas that have the highest return on investment in using technology to modernize how the Freedom of Information Act functions in the United States.
 
-What we think is that these are the areas that have the highest return on investment in using technology to modernize how the Freedom of Information Act functions in the United States.
-
-And **we welcome your help!** 18F is an [open source team](#) working in the public domain, and if you'd like to be a part of that: here we are.
+And **we welcome your help!** 18F is an [open source team](#) working in the public domain &mdash; watch this space, and join us along the way.

--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -1,17 +1,17 @@
 ## FOIA and Technology: a development blog
 
-[18F](https://18f.gsa.gov) has created a delivery team to implement part of the U.S. Governement's [commitment](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf) to modernize the Freedom of Information Act.   
+Hi! We're the team that [18F](https://18f.gsa.gov) created to implement part of the U.S. Governement's [commitment](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf) to modernize the Freedom of Information Act.   
 
-We are tasked with bringing technology to bear on this problem. We are *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
+We're tasked with bringing technology to bear on this problem. We are *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
 
 
 ### Where we are
 
-18F works in the open, and so you can follow our work and project discussions on GitHub, centered at [18F's `foia` repository](https://github.com/18f/foia). You can use GitHub's "Watch" feature to be notified of ongoing discussion in that repository. We'll be trying to do as much project deliberation and stakeholder interaction as possible in GitHub.
+18F works in the open, and so you can follow our work and project discussions online, centered at [18F's `foia` repository](https://github.com/18f/foia). You can use the "Watch" feature to be notified of ongoing discussion in that repository. We'll do as much project deliberation and stakeholder interaction as possible in public.
 
 Over time, the work will likely expand to include multiple repositories tackling more specific elements of the work, but our project-level discussions will remain at [`18f/foia`](https://github.com/18f/foia). So if you want to keep in close touch with the project, that's where to do it.
 
-In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the delivery team will write about our goals, plans, and progress. Compared to GitHub, updates will be less frequent and more narrative, but this is a **development blog** and so it will frequently be "in the weeds" and technical. You can use [our RSS feed](http://18f.github.io/foia/feed/) to follow our updates.
+In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the delivery team will write about our goals, plans, and progress. Compared to a normal software code respository, updates will be less frequent and more narrative, but this is a **development blog** and so it will frequently be "in the weeds" and technical. You can use [our RSS feed](http://18f.github.io/foia/feed/) to follow our updates.
 
 
 ### Our plan
@@ -20,13 +20,13 @@ Our team's plan is to **reduce friction** for requestors and agencies in the FOI
 
 To this end, we're developing, or looking at developing:
 
-* A **consolidated FOIA portal** for requestors. A central, user-facing front-end from which anyone can initiate a FOIA request to an agency in the federal government.
-* A **working API and spec** for agencies to receive FOIA requests and resolve them. In other words, a common way for our portal to cleanly interoperate with an agency's existing or new FOIA processing systems -- at least at the very beginning and end of the process.
+* A **consolidated FOIA tool** for requestors. A central, user-facing front-end from which anyone can start a FOIA request to an agency in the federal government.
+* A **working request and response API and spec** for agencies to get and resolve FOIA requests. In other words, a common way for the tool to work with an agency's FOIA processing systems &mdash; at least at the very beginning and end of the process.
 * An interface for **discovering public records** released through FOIA. At the very least, this means a public read API.
 * A lightweight **application for FOIA offices** to track and process requests. It would use the same interoperable request and response API as described above.
-* Tools to help agencies with **efficient preparing of records** for release. In particular, tools to make responsive documents accessible could increase the quality and quantity of publicly released documents &mdash; and be broadly useful in the federal government beyond FOIA.
+* Tools to help agencies **efficiently prepare records ** for release. In particular, tools to make responsive documents accessible could increase the quality and quantity of publicly released documents &mdash; and be broadly useful in the federal government beyond FOIA.
 
-That's a lot of stuff. We most likely will not end up choosing (or being able) to pursue each of them to completion.
+That's a lot of stuff. We most likely won't end up choosing (or being able) to work on or finish all of them.
 
 What we think is that these are the areas that have the highest return on investment in using technology to modernize how the Freedom of Information Act functions in the United States.
 

--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -1,17 +1,17 @@
 ## FOIA and Technology: a development blog
 
-Hi! We're the team that [18F](https://18f.gsa.gov) created to implement part of the U.S. Governement's [commitment](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf) to modernize the Freedom of Information Act.   
+Welcome! We're the team created by [18F](https://18f.gsa.gov) to implement part of the U.S. Government's [commitment](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf) to modernize the Freedom of Information Act.
 
-We're tasked with bringing technology to bear on this problem. We are *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
+We're tasked with bringing technology to bear on this problem. We're *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
 
 
 ### Where we are
 
-18F works in the open, and so you can follow our work and project discussions online, centered at [18F's `foia` repository](https://github.com/18f/foia). You can use the "Watch" feature to be notified of ongoing discussion in that repository. We'll do as much project deliberation and stakeholder interaction as possible in public.
+18F works in the open, and so you can follow our work and project discussions on GitHub, centered at [18F's `foia` repository](https://github.com/18f/foia). You can use GitHub's "Watch" feature to be notified of ongoing discussion in that repository. We'll do as much project deliberation and stakeholder interaction as possible in GitHub.
 
 Over time, the work will likely expand to include multiple repositories tackling more specific elements of the work, but our project-level discussions will remain at [`18f/foia`](https://github.com/18f/foia). So if you want to keep in close touch with the project, that's where to do it.
 
-In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the delivery team will write about our goals, plans, and progress. Compared to a normal software code respository, updates will be less frequent and more narrative, but this is a **development blog** and so it will frequently be "in the weeds" and technical. You can use [our RSS feed](http://18f.github.io/foia/feed/) to follow our updates.
+In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the delivery team will write about our goals, plans, and progress. Compared to GitHub, updates will be less frequent and more narrative, but this is a **development blog** and so it will frequently be "in the weeds" and technical. You can use [our RSS feed](http://18f.github.io/foia/feed/) to follow our updates.
 
 
 ### Our plan

--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -20,7 +20,7 @@ Our team's plan is to **reduce friction** for requestors and agencies in the FOI
 To this end, we're developing, or looking at developing:
 
 * A **consolidated FOIA tool** for requestors. A central, user-facing front-end from which anyone can start a FOIA request to an agency in the federal government.
-* A **working request and response API and spec** for agencies to get and resolve FOIA requests. In other words, a common way for the tool to work with an agency's FOIA processing systems &mdash; at least at the very beginning and end of the process.
+* A **working request and response API and spec** for agencies to get and resolve FOIA requests. In other words, a common way for the tool to work with an agency's new or existing FOIA processing systems &mdash; at least at the very beginning and end of the process.
 * An interface for **discovering public records** released through FOIA. At the very least, this means a public read API.
 * A lightweight **application for FOIA offices** to track and process requests. It would use the same interoperable request and response API as described above.
 * Tools to help agencies **efficiently prepare records ** for release. In particular, tools to make responsive documents accessible could increase the quality and quantity of publicly released documents &mdash; and be broadly useful in the federal government beyond FOIA.

--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -16,7 +16,7 @@ In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the deliver
 
 ### Our plan
 
-Our team's plan is to **reduce friction** for requestors and agencies in the FOIA process, **absorb the entropy** of petitioning a federated government of autonomous agencies, and **create a clear path** for the release of public records.
+Our team's plan is to **reduce friction** for requestors and agencies in the FOIA process, create **scalable infrastructure** for petitioning a federated government of autonomous agencies, and **clear the path** for the release of public records.
 
 To this end, we're developing, or looking at developing:
 

--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -1,9 +1,11 @@
+## FOIA and Technology: a development blog
+
 [18F](https://18f.gsa.gov) has created a delivery team to implement part of the [Open Government National Action Plan](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf)'s commitment to modernizing the Freedom of Information Act.
 
 We are tasked with bringing technology to bear on this problem. We are *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
 
 
-## Where we are
+### Where we are
 
 18F works in the open, and so you can follow our work and project discussions on GitHub, centered at [18F's `foia` repository](https://github.com/18f/foia). You can use GitHub's "Watch" feature to be notified of ongoing discussion in that repository. We'll be trying to do as much project deliberation and stakeholder interaction as possible in GitHub.
 
@@ -12,7 +14,7 @@ Over time, the work will likely expand to include multiple repositories tackling
 In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the delivery team will write about our goals, plans, and progress. Compared to GitHub, updates will be less frequent and more narrative, but this is a **development blog** and so it will frequently be "in the weeds" and technical. You can use [our RSS feed](http://18f.github.io/foia/feed/) to follow our updates.
 
 
-## Our plan
+### Our plan
 
 Our team's plan is to **reduce friction** for requestors and agencies in the FOIA process, **absorb the entropy** of petitioning a federated government of autonomous agencies, and **create a clear path** for the release of public records.
 

--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -15,7 +15,7 @@ In *this* space ([18f.github.io/foia](https://18f.github.io/foia/)), the develop
 
 ### Our plan
 
-Our team's plan is to **reduce friction** for requestors and agencies in the FOIA process, create **scalable infrastructure** for petitioning a federated government of autonomous agencies, and **clear the path** for the release of public records.
+Our team's plan is to **reduce friction** for requestors and agencies in the FOIA process, create **scalable infrastructure** for making requests of a federated government of agencies and components, and **clear the path** for agencies to release public records.
 
 To this end, we're developing, or looking at developing:
 

--- a/posts/2014-06-23-introduction.md
+++ b/posts/2014-06-23-introduction.md
@@ -1,6 +1,6 @@
 ## FOIA and Technology: a development blog
 
-[18F](https://18f.gsa.gov) has created a delivery team to implement part of the [Open Government National Action Plan](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf)'s commitment to modernizing the Freedom of Information Act.
+[18F](https://18f.gsa.gov) has created a delivery team to implement part of the U.S. Governement's [commitment](http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf) to modernize the Freedom of Information Act.   
 
 We are tasked with bringing technology to bear on this problem. We are *not tasked* with developing new regulations or legislation. Of course, neither policy nor technology exists in a vacuum, and they will depend heavily on each other.
 


### PR DESCRIPTION
This is my first attempt at an introductory post for our FOIA product blog. 

**[Read the post in full here.](https://github.com/18F/foia/blob/intro/posts/2014-06-23-introduction.md)**

It wouldn't be out of place on 18F's [main blog](http://18fblog.tumblr.com), and probably has some overlap with the post @rjmajma has been working on there. But my goals here are to:
- Introduce the blog, and the repository.
- Communicate the current state of our project plans (as we've communicated internally, and to the task force, and to the rest of 18F) to the rest of the world.

Please use this PR to give feedback on how well it's achieving those, and to make non-controversial or consensus-gained commits on the `intro` branch directly, pre-merge.

In general, I'm hoping we'll all feel free to post as frequently and as technically as we want, without having to schedule time on the 18F blog, or worry about alienating less technical readers. Also, not all posts will be technical -- this one clearly isn't, and instead it serves as a development marker and something we can point to for others.

I'll also add that I've become a big fan of the [open, narrative pull request](https://github.com/18F/foia/pull/4). I'm hoping we'll do a bunch of those, with a positive incentive that some PRs could be quickly adapted into blog posts.

This is on a `gh-pages` branch, because I'm intending this to start out at `https://18f.github.io/foia`. Certainly possible that this changes over time. I don't have an actual Jekyll site, much less a theme, ready, but that will be next and can be set up in parallel to actually approving the content.

Still to do:
- [ ] Create a basic Jekyll site, with theme, and with RSS feed.
- [ ] Add a link to a yet-to-be-created issue/PR around an API specification. (Could be post-publish.)
- [ ] Add a link to our yet-to-be-published 18F blog post about our open source policy. (Could be post-publish.)
