### PR TITLE
Finish python rewrite

### DIFF
--- a/contacts/requirements.txt
+++ b/contacts/requirements.txt
@@ -1,4 +1,6 @@
 beautifulsoup4
+pyyaml
 
-nose
 flake8
+mock
+nose

--- a/contacts/scraper.py
+++ b/contacts/scraper.py
@@ -10,6 +10,8 @@ from urllib.request import urlopen
 from bs4 import BeautifulSoup
 import yaml
 
+import typos
+
 
 # Transformed from the `agenciesFile` array at
 # http://www.foia.gov/foiareport.js
@@ -213,8 +215,8 @@ def parse_agency(abb, doc):
 
 def fix_known_typos(text):
     """Account for faulty data"""
-    # see http://foia.msfc.nasa.gov/reading.html
-    text = text.replace("(256) 544-007 ", "(256) 544-0007 ")
+    for error, fix in typos.REPLACEMENTS.items():
+        text = text.replace(error, fix)
     return text
 
 

--- a/contacts/scraper.py
+++ b/contacts/scraper.py
@@ -1,4 +1,5 @@
 from itertools import takewhile
+import logging
 import os
 from random import randint
 import re
@@ -222,19 +223,19 @@ def save_agency(abb):
     process it, and save the resulting YAML"""
     if not os.path.isdir("html"):
         os.mkdir("html")
-    html_path = "html/%s.html" % abb
+    html_path = "html" + os.sep + "%s.html" % abb
     if not os.path.isfile(html_path):
         body = ""
         body = download_agency(abb)
         if body:
             with open(html_path, 'w') as f:
                 f.write(body)
-            print("[%s] Downloaded." % abb)
+            logging.info("[%s] Downloaded.", abb)
         else:
-            print("[%s] DID NOT DOWNLOAD, NO." % abb)
+            logging.warning("[%s] DID NOT DOWNLOAD, NO.", abb)
             return
     else:
-        print("[%s] Already downloaded." % abb)
+        logging.info("[%s] Already downloaded.", abb)
 
     with open(html_path, 'r') as f:
         text = f.read()
@@ -243,12 +244,12 @@ def save_agency(abb):
     if not os.path.isdir("data"):
         os.mkdir("data")
     if data:
-        with open("data/%s.yaml" % abb, 'w') as f:
+        with open("data" + os.sep + "%s.yaml" % abb, 'w') as f:
             f.write(yaml.dump(data, default_flow_style=False,
                     allow_unicode=True))
-            print("[%s] Parsed." % abb)
+            logging.info("[%s] Parsed.", abb)
     else:
-        print("[%s] DID NOT PARSE, NO." % abb)
+        logging.warning("[%s] DID NOT PARSE, NO.", abb)
 
 
 def save_agencies():
@@ -269,10 +270,14 @@ def download_agency(abb):
     return urlopen(url).read().decode("utf-8")
 
 
-# `python agencies.py` does everything.
-# `python agencies.py AGENCY` does just one agency.
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    agency_name = None
     if len(sys.argv) > 1 and sys.argv[1].strip():
-        save_agency(sys.argv[1])
+        agency_name = sys.argv[1].strip()
+
+    if agency_name:
+        save_agency(agency_name)
     else:
         save_agencies()

--- a/contacts/tests.py
+++ b/contacts/tests.py
@@ -164,3 +164,7 @@ class ScraperTests(TestCase):
         self.assertEqual(hq_call[0][1], "Headquarters")
         self.assertEqual(chicago_call[0][0]['id'], "2")
         self.assertEqual(chicago_call[0][1], "Chicago Branch")
+
+    def test_agency_url(self):
+        self.assertTrue("agency=ABCDEF" in scraper.agency_url("ABCDEF"))
+        self.assertTrue("agency=A+B+C+D" in scraper.agency_url("A B C D"))

--- a/contacts/typos.py
+++ b/contacts/typos.py
@@ -1,0 +1,6 @@
+"""Collection of tweaks to fix FOIA data"""
+
+# see http://foia.msfc.nasa.gov/reading.html
+REPLACEMENTS = {
+    "(256) 544-007 ": "(256) 544-0007 "
+}


### PR DESCRIPTION
This finished the conversion of the ruby script to scrape contacts.

The output yaml is different in a few ways, but none significant. The keys are re-ordered (making direct comparison difficult), some syntax is different (preferring single quotes instead of double quotes, etc.), and there's a few odds and ends with newlines.

I spot-checked to verify around forty agencies; seems okay.
