### PR TITLE
Separating out manually added data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 todo.txt
 /documents/*.html
 /misc
+*.swp

--- a/contacts/explorer.py
+++ b/contacts/explorer.py
@@ -26,7 +26,7 @@ def process_yaml_data(data_key):
                 count += 1
             else:
                 # Print out the values to the variance in the information.
-                #print(data['name'])  # Get agency name
+                # print(data['name'])  # Get agency name
                 print(data_value)
 
     print('------------------------------------------------------')

--- a/contacts/manual_data/CFPB.yaml
+++ b/contacts/manual_data/CFPB.yaml
@@ -1,0 +1,4 @@
+keywords:
+- HMDA
+- credit cards
+- mortgage

--- a/contacts/manual_data/CIA.yaml
+++ b/contacts/manual_data/CIA.yaml
@@ -1,0 +1,4 @@
+keywords:
+- spies
+- espionage
+- counterintelligence

--- a/contacts/manual_data/DHS.yaml
+++ b/contacts/manual_data/DHS.yaml
@@ -1,0 +1,15 @@
+departments:
+- name: U.S. Citizenship & Immigration Services
+  top_level: true
+- name: U.S. Coast Guard
+  top_level: true
+- name: U.S. Customs & Border Protection
+  top_level: true
+- name: Federal Emergency Management Agency
+  top_level: true
+- name: Federal Law Enforcement Training Center
+  top_level: true
+- name: U.S. Immigration & Customs Enforcement
+  top_level: true
+- name: United States Secret Service
+  top_level: true

--- a/contacts/manual_data/DOC.yaml
+++ b/contacts/manual_data/DOC.yaml
@@ -1,0 +1,15 @@
+departments:
+- name: Census Bureau
+  top_level: true
+- name: International Trade Administration
+  top_level: true
+- name: Minority Business Development Agency
+  top_level: true
+- name: National Institute of Standards and Technology
+  top_level: true
+- name: National Technical Information Service
+  top_level: true
+- name: National Oceanic and Atmospheric Administration
+  top_level: true
+- name: U.S. Patent and Trademark Office
+  top_level: true

--- a/contacts/manual_data/DOE.yaml
+++ b/contacts/manual_data/DOE.yaml
@@ -1,0 +1,3 @@
+departments:
+- name: Office of Scientific and Technical Information
+  top_level: true

--- a/contacts/manual_data/DOI.yaml
+++ b/contacts/manual_data/DOI.yaml
@@ -1,0 +1,15 @@
+departments:
+- name: Bureau of Indian Affairs
+  top_level: true
+- name: Bureau of Land Management
+  top_level: true
+- name: Bureau of Ocean Energy Management
+  top_level: true
+- name: Bureau of Reclamation
+  top_level: true
+- name: Bureau of Safety and Environmental Enforcement
+  top_level: true
+- name: U.S. Fish and Wildlife Service
+  top_level: true
+- name: National Park Service
+  top_level: true

--- a/contacts/manual_data/DOJ.yaml
+++ b/contacts/manual_data/DOJ.yaml
@@ -7,6 +7,7 @@ departments:
   top_level: true
 - name: Federal Bureau of Investigation
   top_level: true
+  description: "As an intelligence-driven and a threat-focused national security organization with both intelligence and law enforcement responsibilities, the mission of the FBI is to protect and defend the United States against terrorist and foreign intelligence threats, to uphold and enforce the criminal laws of the United States, and to provide leadership and criminal justice services to federal, state, municipal, and international agencies and partners."
 - name: Federal Bureau of Prisons
   top_level: true
 - name: Office of Community Oriented Policing Services

--- a/contacts/manual_data/DOJ.yaml
+++ b/contacts/manual_data/DOJ.yaml
@@ -1,0 +1,15 @@
+departments:
+- name: Office of the Attorney General
+  top_level: true
+- name: Bureau of Alcohol, Tobacco, Firearms, and Explosives
+  top_level: true
+- name: Drug Enforcement Administration
+  top_level: true
+- name: Federal Bureau of Investigation
+  top_level: true
+- name: Federal Bureau of Prisons
+  top_level: true
+- name: Office of Community Oriented Policing Services
+  top_level: true
+- name: United States Marshals Service
+  top_level: true

--- a/contacts/manual_data/DOT.yaml
+++ b/contacts/manual_data/DOT.yaml
@@ -1,0 +1,5 @@
+departments:
+- name: Federal Aviation Administration
+  top_level: true
+- name: National Highway Traffic Safety Administration
+  top_level: true

--- a/contacts/manual_data/DoD.yaml
+++ b/contacts/manual_data/DoD.yaml
@@ -1,0 +1,19 @@
+departments:
+- name: Office of the Secretary and Joint Staff
+  top_level: true
+- name: Department of the Air Force
+  top_level: true
+- name: Department of the Army
+  top_level: true
+- name: Department of the Navy
+  top_level: true
+- name: Marine Corps
+  top_level: true
+- name: National Geographic Intelligence Agency
+  top_level: true
+- name: National Guard Bureau
+  top_level: true
+- name: National Reconnaissance Office
+  top_level: true
+- name: National Security Agency
+  top_level: true

--- a/contacts/manual_data/GSA.yaml
+++ b/contacts/manual_data/GSA.yaml
@@ -1,0 +1,61 @@
+keywords:
+- purchase cards
+- federal contracts
+- government forms
+- Property Auction - Buildings/land/lighthouses
+- Property Disposal
+- Property Donation
+- Supply Auction
+- Contracts
+- Contract Task Orders
+- General Schedule Contracts
+- Contractual Awards and selection
+- Courthouses
+- Construction
+- Renovation
+- Federal Buildings
+- Construction or Renovation Costs
+- Operation and Maintenance Costs
+- Federal Building Sales
+- Land Port of Entry Construction/Modifications
+- GSA/Congressional and Intergovernmental Affairs Communications
+- GSA Advantage Program
+- GSA/Federal Government Per Diem Program
+- GSA Schedules Program
+- GSA Pricing of goods and services offered
+- Procurement
+- GSA Prospectus
+- Donation Program
+- Travel Program Information
+- Child Care Centers
+- Governmentwide Policies and Regulations
+- Green Buildings
+- Energy Efficiency
+- LEED Certified Buildings
+- Architecture
+- Artwork in Government Buildings
+- Historical Building Preservation
+- Monuments - Historical Preservation
+- Building Performance
+- Small Business
+- Government Social Media
+- First Class/Premium Travel
+- GSA Global Supply
+- Assisted Acquisition
+- Personal Property Management
+- GSA Multiple Award Schedule
+- Federal Travel Regulation (FTR)
+- Federal Acquisition Regulation (FAR)
+- Federal Management Regulation (FMR)
+- General Services Acquisition Manual (GSAM)
+- Government Travel Charge Cards
+- Government Travel Information - Premium Travel
+- Government Purchase Card Program
+- Government Travel Card Program
+- Fleet Management
+- Owned Vehicle Fleet
+- Leased Vehicle Fleet
+- Building Maintenance Reports
+- Elevator Service Reports
+- Incident/Accident Reports
+- Governmentwide Policy and Regulation

--- a/contacts/manual_data/GSA.yaml
+++ b/contacts/manual_data/GSA.yaml
@@ -1,3 +1,7 @@
+common_requests:
+- Federal contracts
+- Purchase card use
+- Government forms
 keywords:
 - purchase cards
 - federal contracts

--- a/contacts/manual_data/HHS.yaml
+++ b/contacts/manual_data/HHS.yaml
@@ -1,0 +1,19 @@
+departments:
+- name: Administration for Community Living
+  top_level: true
+- name: Agency for Healthcare Research and Quality
+  top_level: true
+- name: Centers for Disease Control and Prevention
+  top_level: true
+- name: Center for Medicare and Medicaid Services
+  top_level: true
+- name: Food and Drug Administration
+  top_level: true
+- name: Health Resources and Services Administration
+  top_level: true
+- name: Indian Health Service
+  top_level: true
+- name: National Institutes of Health
+  top_level: true
+- name: Substance Abuse and Mental Health Services Administration
+  top_level: true

--- a/contacts/manual_data/NASA.yaml
+++ b/contacts/manual_data/NASA.yaml
@@ -1,0 +1,5 @@
+departments:
+- name: Jet Propulsion Laboratory
+  top_level: true
+- name: NASA Shared Services Center
+  top_level: true

--- a/contacts/manual_data/OSTP.yaml
+++ b/contacts/manual_data/OSTP.yaml
@@ -1,3 +1,7 @@
+common_requests:
+- "Records on OSTP's scientific advice and correspondance."
+no_records_about:
+- General White House correspondance or documents.
 keywords:
 - white house
 - cto

--- a/contacts/manual_data/OSTP.yaml
+++ b/contacts/manual_data/OSTP.yaml
@@ -1,0 +1,3 @@
+keywords:
+- white house
+- cto

--- a/contacts/manual_data/Treasury.yaml
+++ b/contacts/manual_data/Treasury.yaml
@@ -1,0 +1,13 @@
+departments:
+- name: Alcohol and Tobacco Tax and Trade Bureau
+  top_level: true
+- name: Bureau of Engraving and Printing
+  top_level: true
+- name: Comptroller of the Currency
+  top_level: true
+- name: Financial Crimes Enforcement Network
+  top_level: true
+- name: Internal Revenue Service
+  top_level: true
+- name: United States Mint
+  top_level: true

--- a/contacts/manual_data/U.S. DOL.yaml
+++ b/contacts/manual_data/U.S. DOL.yaml
@@ -1,0 +1,15 @@
+departments:
+- name: Bureau of International Labor Affairs
+  top_level: true
+- name: Bureau of Labor Statistics
+  top_level: true
+- name: Employee Benefits Security Administration
+  top_level: true
+- name: Employment & Training Administration
+  top_level: true
+- name: Job Corps
+  top_level: true
+- name: Mine Safety & Health Administration
+  top_level: true
+- name: Occupational Safety & Health Administration
+  top_level: true

--- a/contacts/manual_data/USPS.yaml
+++ b/contacts/manual_data/USPS.yaml
@@ -1,0 +1,3 @@
+departments:
+- name: Postal Inspection Service
+  top_level: true

--- a/contacts/scraper.py
+++ b/contacts/scraper.py
@@ -244,8 +244,7 @@ def add_top_level(abbr, agency):
 def save_agency(abb):
     """For a given agency, download (if not already present) their HTML,
     process it, and save the resulting YAML"""
-    if not os.path.isdir("html"):
-        os.mkdir("html")
+    os.makedirs('html', exist_ok=True)
     html_path = "html" + os.sep + "%s.html" % abb
     if not os.path.isfile(html_path):
         body = ""
@@ -264,15 +263,20 @@ def save_agency(abb):
         text = f.read()
     text = fix_known_typos(text)
     data = parse_agency(abb, BeautifulSoup(text))
-    if not os.path.isdir("data"):
-        os.mkdir("data")
+
+    save_agency_data(abb, data)
+
+def save_agency_data(agency_abbr, data, data_directory='data'):
+    """ Actually do the save. """
+    os.makedirs(data_directory, exist_ok=True)
+
     if data:
-        with open("data" + os.sep + "%s.yaml" % abb, 'w') as f:
+        with open(data_directory + os.sep + "%s.yaml" % agency_abbr, 'w') as f:
             f.write(yaml.dump(data, default_flow_style=False,
                     allow_unicode=True))
-            logging.info("[%s] Parsed.", abb)
+            logging.info("[%s] Parsed.", agency_abbr)
     else:
-        logging.warning("[%s] DID NOT PARSE, NO.", abb)
+        logging.warning("[%s] DID NOT PARSE, NO.", agency_abbr)
 
 
 def save_agencies():

--- a/contacts/scraper.py
+++ b/contacts/scraper.py
@@ -266,6 +266,7 @@ def save_agency(abb):
 
     save_agency_data(abb, data)
 
+
 def save_agency_data(agency_abbr, data, data_directory='data'):
     """ Actually do the save. """
     os.makedirs(data_directory, exist_ok=True)
@@ -298,12 +299,11 @@ def download_agency(abb):
 
 
 if __name__ == "__main__":
-    """ 
+    """
         python scraper.py <<agency_abbreviation>>
-        will only scrape and save the data for the provided agency. 
+        will only scrape and save the data for the provided agency.
 
-        python scraper.py will scrape and save data for all the agencies. 
-    
+        python scraper.py will scrape and save data for all the agencies.
     """
     logging.basicConfig(level=logging.INFO)
 

--- a/contacts/tests.py
+++ b/contacts/tests.py
@@ -1,8 +1,10 @@
+import os
 from copy import deepcopy
 from unittest import TestCase
 
 from bs4 import BeautifulSoup
 from mock import Mock, patch
+import yaml
 
 import keywords_from_fr as fr
 import layer_with_csv as layer
@@ -10,6 +12,13 @@ import scraper
 
 
 class ScraperTests(TestCase):
+    def test_save_agency_data(self):
+        scraper.save_agency_data(
+            'TEST', {'name': 'Test Agency'}, data_directory='/tmp/test/')
+        self.assertTrue(os.path.isfile('/tmp/test/TEST.yaml'))
+        test_data = yaml.load(open('/tmp/test/TEST.yaml', 'r'))
+        self.assertEqual({'name': 'Test Agency'}, test_data)
+
     def test_agency_description(self):
         """Description should be pulled out and BRs should be converted"""
         html = """

--- a/contacts/typos2manual.py
+++ b/contacts/typos2manual.py
@@ -1,0 +1,27 @@
+import scraper
+import typos
+
+
+if __name__ == "__main__":
+    """ This one-time use script is designed to take everything in typos.py and
+    create manual override YAML files for the agencies. """
+
+    agencies = {}
+        
+    for agency in typos.KEYWORDS.keys():
+        data = {}
+        data = scraper.add_keywords(agency, data)
+        agencies[agency] = data
+
+    for agency in typos.TOP_LEVEL.keys():
+        departments = []
+
+        for department in typos.TOP_LEVEL[agency]:
+            department = {'name': department, 'top_level':True}
+            departments.append(department)
+
+        data = agencies.get(agency, {})
+        agencies[agency] = dict(data, departments=departments)
+
+    for agency in agencies:
+        scraper.save_agency_data(agency, agencies[agency], 'manual_data')

--- a/contacts/typos2manual.py
+++ b/contacts/typos2manual.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     create manual override YAML files for the agencies. """
 
     agencies = {}
-        
+
     for agency in typos.KEYWORDS.keys():
         data = {}
         data = scraper.add_keywords(agency, data)
@@ -17,7 +17,7 @@ if __name__ == "__main__":
         departments = []
 
         for department in typos.TOP_LEVEL[agency]:
-            department = {'name': department, 'top_level':True}
+            department = {'name': department, 'top_level': True}
             departments.append(department)
 
         data = agencies.get(agency, {})


### PR DESCRIPTION
We have two kinds of agency contact data: 

(1) That which is scraped or other retrieved by scripts.
(2) That which is manually entered. 

The manually entered data currently gets overwritten if the scraper.py script is run. In order to fix this, this PR creates a new set of YAML files in manual_data that contain the manual overrides. Eventually, the scraper will prioritize using the manual overrides always. 

I figured I'd get this first piece in. 

This sets us up for a better future too. Anything can be added to the manual YAML files and will make it into the generated YAML files even if scripts are run. 

I also clean up scraper.py a little bit. 
