### PR TITLE
Default top-level to false + typo fix

### DIFF
--- a/contacts/layer_with_usa_contacts.py
+++ b/contacts/layer_with_usa_contacts.py
@@ -57,7 +57,7 @@ def load_all_usa_data():
 
             data[office['Name']] = {
                                 'description':office.get(
-                                'Description', 'No Description'),
+                                'description', 'No Description'),
                                 'id':office.get('Id', 'No Id'),
                                 'acronym_usa_contacts':extract_acronym(office['Name'])
                                 }

--- a/contacts/scraper.py
+++ b/contacts/scraper.py
@@ -166,7 +166,7 @@ def find_bold_fields(ps):
 
 def parse_department(elem, name):
     """Get data from a 'div' (elem) associated with a single department"""
-    data = {"name": name}
+    data = {"name": name, "top_level": False}
     lines, ps = clean_paragraphs(elem)
     # remove first el (which introduces the section)
     lines, ps = lines[1:], ps[1:]


### PR DESCRIPTION
This guarantees the field will be present on all "departments"

Also uses lowercase "description" where appropriate.
