### PR TITLE
added regex to remove extra spaces in full-foia-contacts.xls

### DIFF
--- a/contacts/data/DHS.yaml
+++ b/contacts/data/DHS.yaml
@@ -24,18 +24,25 @@ departments:
   - National Records Center, FOIA/PA Office
   - P.O. Box 648010
   - Lee's Summit, MO 64064-8010
-  description: U.S. Citizenship and Immigration Services oversees immigration to the
-    United States.
+  description: No Description
   emails:
   - uscis.foia@dhs.gov
   fax: 816-350-5785
   foia_officer: 'Jill Eggleston, Phone: (800) 375-5283 (USCIS National Customer Service
     Unit)'
   keywords:
+  - Administrative practice and procedure
+  - Aliens
   - Authority delegations (Government agencies)
+  - Employment
+  - Foreign officials
   - Freedom of information
+  - Health professions
+  - Immigration
+  - Penalties
   - Privacy
   - Reporting and recordkeeping requirements
+  - Students
   - Surety bonds
   name: U.S. Citizenship & Immigration Services
   notes: This office has additional FOIA contact information that can be found by
@@ -69,8 +76,7 @@ departments:
   - 'Commandant (CG-611), ATTN: FOIA Coordinator'
   - 2703 Martin Luther King Jr Ave
   - Washington, DC 20593-7710
-  description: The U.S. Coast Guard safeguards the maritime interests of the United
-    States and the environment around the world.
+  description: No Description
   emails:
   - efoia@uscg.mil
   fax: 202-475-3927
@@ -199,8 +205,7 @@ departments:
   - 90 K Street, NE
   - 9th Floor
   - Washington, DC 20229-1181
-  description: 'Customs and Border Protection prevents people from entering the country
-    illegally, or bringing anything harmful or illegal into the United States. '
+  description: No Description
   fax: 202-325-0230
   foia_officer: 'Sabrina Burroughs, Phone: (202) 325-0150'
   keywords:
@@ -314,9 +319,7 @@ departments:
   - Room 840
   - 500 C Street, SW
   - Washington, DC 20472
-  description: FEMA supports citizens and emergency personnel to build, sustain, and
-    improve the nations capability to prepare for, protect against, respond to, recover
-    from, and mitigate all hazards.
+  description: No Description
   emails:
   - fema-foia@dhs.gov
   fax: 202-646-3347
@@ -403,9 +406,7 @@ departments:
   - FOIA Officer
   - 'Building #681, Suite 187B'
   - Glynco, GA 31524
-  description: The Federal Law Enforcement Training Center provides law enforcement
-    training for 91 federal agencies, several state, local, and tribal agencies, and
-    oversees or assists with training at serveral International Law Enforcement Academies.
+  description: No Description
   emails:
   - fletc-foia@dhs.gov
   fax: 912-267-3113
@@ -425,8 +426,7 @@ departments:
   - Mail Stop 5009
   - 500 12th Street, SW
   - Washington, DC 20536-5009
-  description: Immigration and Customs Enforcement enforces federal laws governing
-    border control, customs, trade, and immigration.
+  description: No Description
   emails:
   - ice-foia@dhs.gov
   fax: 202-732-4265
@@ -458,6 +458,33 @@ departments:
   - foia.oig@oig.dhs.gov
   fax: 202-254-4398
   foia_officer: 'Stephanie Kuehn, Phone: (202) 254-4001'
+  keywords:
+  - Accounting
+  - Administrative practice and procedure
+  - Biologics
+  - Drugs
+  - Emergency medical services
+  - Fraud
+  - Freedom of information
+  - Grant programs-health
+  - Health facilities
+  - Health insurance
+  - Health professions
+  - Hospitals
+  - Investigations
+  - Kidney diseases
+  - Maternal and child health
+  - Medicaid
+  - Medical devices
+  - Medicare
+  - Packaging and containers
+  - Penalties
+  - Privacy
+  - Reporting and recordkeeping requirements
+  - Rural areas
+  - Social security
+  - Transportation
+  - X-rays
   name: Office of the Inspector General
   phone: 202-254-4001
   public_liaison: 'Aneet Thind, Phone: (202) 254-4001'
@@ -529,9 +556,7 @@ departments:
   - Building 410
   - 245 Murray Drive
   - Washington, DC 20223
-  description: The Secret Service works to safeguard the nation's financial infrastructure.
-    The Secret Service is also responsible for protecting national leaders, visiting
-    heads of state, and National Special Security Events.
+  description: No Description
   emails:
   - FOIA@usss.dhs.gov
   fax: 202-406-5586
@@ -545,6 +570,74 @@ departments:
   top_level: true
   usa_id: '49660'
   website: http://www.secretservice.gov/foia.shtml
+- address:
+  - Yvonne Coates
+  - FOIA Officer
+  - 11th Floor, East Tower, TSA-20
+  - 601 S. 12th Street
+  - Arlington, VA 22202-4220
+  emails:
+  - foia.tsa@dhs.gov
+  fax: 571-227-1406
+  foia_officer: 'Yvonne Coates, Phone: (866) 364-2872, (571) 227-2300'
+  keywords:
+  - Accounting
+  - Administrative practice and procedure
+  - Afghanistan
+  - Agriculture
+  - Air carriers
+  - Air taxis
+  - Air traffic control
+  - Air transportation
+  - Aircraft
+  - Airmen
+  - Airports
+  - Alcohol abuse
+  - Arms and munitions
+  - Authority delegations (Government agencies)
+  - Aviation safety
+  - Canada
+  - Charter flights
+  - Cuba
+  - Drug abuse
+  - Drug testing
+  - Ethiopia
+  - Explosives
+  - Freight
+  - Freight forwarders
+  - Government employees
+  - Harbors
+  - Hazardous materials transportation
+  - Investigations
+  - Law enforcement
+  - Law enforcement officers
+  - Maritime carriers
+  - Maritime security
+  - Mass transportation
+  - Mexico
+  - Motor carriers
+  - Noise control
+  - Organization and functions (Government agencies)
+  - Penalties
+  - Political candidates
+  - Privacy
+  - Railroad safety
+  - Railroads
+  - Reporting and recordkeeping requirements
+  - Safety
+  - Schools
+  - Seamen
+  - Security measures
+  - Transportation
+  - Vessels
+  - Waterways
+  - Yugoslavia
+  name: Transportation Security Administration
+  phone: 866-364-2872
+  public_liaison: 'Yvonne Coates, Phone: (866) 364-2872'
+  service_center: 'Phone: (866) 364-2872, (571) 227-2300'
+  top_level: false
+  website: http://www.tsa.gov/research/foia/index.shtm
 - address:
   - Michael Johnson
   - FOIA Officer

--- a/contacts/data/DOC.yaml
+++ b/contacts/data/DOC.yaml
@@ -49,6 +49,45 @@ departments:
   top_level: false
   website: https://www.esa.doc.gov/freedom-information-act
 - address:
+  - Stephen Kong
+  - FOIA Officer
+  - Room 7325
+  - 1401 Constitution Avenue, NW
+  - Washington, DC 20230
+  emails:
+  - SKong@eda.doc.gov
+  fax: 202-482-5671
+  foia_officer: 'Stephen Kong, Phone: (202) 482-3085'
+  keywords:
+  - Administrative practice and procedure
+  - Aged
+  - Business and industry
+  - Civil rights
+  - Community development
+  - Environmental protection
+  - Equal employment opportunity
+  - Freedom of information
+  - Grant programs
+  - Grant programs-business
+  - Grant programs-housing and community development
+  - Individuals with disabilities
+  - Loan programs-business
+  - Loan programs-housing and community development
+  - Manpower training programs
+  - Mortgages
+  - Organization and functions (Government agencies)
+  - Reporting and recordkeeping requirements
+  - Research
+  - Sex discrimination
+  - Technical assistance
+  - Trade adjustment assistance
+  name: Economic Development Administration
+  phone: 202-482-3085
+  public_liaison: 'Stephen Kong, Phone: (202) 482-3085'
+  service_center: 'Phone: (202) 482-3085'
+  top_level: false
+  website: http://www.eda.gov/foia.htm
+- address:
   - Jennifer Kuo
   - FOIA Officer
   - Room 6622
@@ -97,13 +136,35 @@ departments:
   - Room 40003
   - 1401 Constitution Avenue, NW
   - Washington, DC 20230
-  description: The International Trade Administration works to promote U.S. exports
-    by providing diplomatic support, helping to shape trade policy, removing trade
-    barriers, and enforcing U.S. trade laws and agreements.
+  description: No Description
   emails:
   - FOIA@trade.gov
   fax: 202-482-1584
   foia_officer: 'Justin Guz, Phone: (202) 482-7937'
+  keywords:
+  - Administrative practice and procedure
+  - American Samoa
+  - Antidumping
+  - Business and industry
+  - Cheese
+  - Confidential business information
+  - Countervailing duties
+  - Customs duties and inspection
+  - Educational facilities
+  - Emergency powers
+  - Freedom of information
+  - Guam
+  - Imports
+  - Investigations
+  - Marketing quotas
+  - Nonprofit organizations
+  - Northern Mariana Islands
+  - Reporting and recordkeeping requirements
+  - Scientific equipment
+  - Steel
+  - Textiles
+  - Virgin Islands
+  - Watches and jewelry
   name: International Trade Administration
   phone: 202-482-7937
   public_liaison: 'Justin Guz, Phone: (202) 482-7937'
@@ -117,9 +178,7 @@ departments:
   - FOIA Officer
   - 1401 Constitution Avenue, NW
   - Washington, DC 20230
-  description: By providing techincal assistance and access to capital, contract opportunities,
-    and new markets, the Minority Business Development Agency promotes the growth
-    of businesses owned and operated by members of the minority and Diaspora communities.
+  description: No Description
   fax: 202-482-2798
   foia_officer: 'Clara Colbert, Phone: (202) 481-5045'
   name: Minority Business Development Agency
@@ -136,9 +195,7 @@ departments:
   - Stop 1710
   - 100 Bureau Drive
   - Gaithersburg, MD 20899-1710
-  description: The National Institute of Standards and Technology promotes measurement
-    standards, conducts a wide array of scientifc research, and offers smaller manufacturers
-    technical and business assistance.
+  description: No Description
   emails:
   - foia@nist.gov
   fax: 301-975-5301
@@ -173,10 +230,7 @@ departments:
   - Number 305 - Sils Building
   - 5301 Shawnee Road
   - Alexandria, VA 22312
-  description: The National Technical Information Service provides businesses, universities,
-    and the public access to government-funded scientific, engineering, technical,
-    and business related information. The service does not use appropriated funds,
-    so charges a fee for its services.
+  description: No Description
   emails:
   - LHalvorsen@ntis.gov
   fax: 703-605-6764
@@ -231,10 +285,7 @@ departments:
   - Room 9719 - NOAA FOIA Office (SOU 10000)
   - 1315 East-West Highway
   - Silver Spring, MD 20910
-  description: The National Oceanic and Atmospheric Administration's mission is to
-    understand and predict changes in climate, weather, oceans, and coasts. The products
-    and services produced by the administration support a number of functions, including
-    severe weather preparedness, and international trade through shipping.
+  description: No Description
   emails:
   - FOIA@noaa.gov
   fax: 301-713-1169
@@ -319,8 +370,7 @@ departments:
   - FOIA Contact
   - P.O. Box 1450
   - Alexandria, VA 22313-1450
-  description: The U.S. Patent and Trademark Office is the agency responsible for
-    granting U.S. patents and registering trademarks.
+  description: No Description
   emails:
   - efoia@uspto.gov
   fax: 571-501-7335

--- a/contacts/data/DOE.yaml
+++ b/contacts/data/DOE.yaml
@@ -71,9 +71,7 @@ departments:
   - FOIA Officer
   - 1 Science.gov Way
   - Oak Ridge, TN 37830
-  description: The Office of Scientific and Technical Information collects, preserves,
-    and makes available the results of research and development carried out or sponsored
-    by the Department of Energy.
+  description: No Description
   emails:
   - wilsonm@osti.gov
   fax: 865-576-3589

--- a/contacts/data/DOI.yaml
+++ b/contacts/data/DOI.yaml
@@ -7,10 +7,7 @@ departments:
   - MS-3071, MIB
   - 1849 C Street, NW
   - Washington, DC 20240
-  description: The Bureau of Indian Affairs’ mission is to enhance the quality of
-    life, to promote economic opportunity, and to carry out the responsibility to
-    protect and improve the trust assets of American Indians, Indian tribes and Alaska
-    Natives.
+  description: No Description
   emails:
   - foia@bia.gov
   fax: 202-208-6597
@@ -70,8 +67,7 @@ departments:
   - 'Attn: FOIA, Washington Office Coorindators'
   - 'MS: WO-560, 1849 C Street, NW'
   - Washington, DC 20240
-  description: The Bureau of Land Management manages outdoor recreation, livestock
-    grazing, mineral development, and energy production on public lands.
+  description: No Description
   emails:
   - BLM_WO_FOIA@blm.gov
   foia_officer: 'Ryan Witt, Phone: (202) 912-7650'
@@ -143,9 +139,7 @@ departments:
   - HM3127
   - 381 Elden Street
   - Herndon, VA 20170-4817
-  description: The Bureau of Ocean Energy Management promotes energy independence,
-    environmental protection, and economic development by managing offshore energy
-    resources.
+  description: No Description
   emails:
   - BOEMFOIA@boem.gov
   fax: 703-787-1209
@@ -193,8 +187,7 @@ departments:
   - FOIA Officer
   - P.O. Box 25007
   - Denver, CO 80225-0007
-  description: 'The Bureau of Reclamation is a provider of wholesale water, and hydroelectric
-    power in the U.S. '
+  description: No Description
   emails:
   - bor_foia@usbr.gov
   fax: 303-445-6575
@@ -234,9 +227,7 @@ departments:
   - 'MS:  HE-2204'
   - 381 Elden Street
   - Herndon, VA 20170-4817
-  description: The Bureau of Safety and Environmental Enforcement provides oversight
-    and enforcement to promote safety, protect the environment, and conserve offshore
-    resources.
+  description: No Description
   emails:
   - BSEEFOIA@bsee.gov
   fax: 703-787-1207
@@ -279,8 +270,7 @@ departments:
   - MS-IRTM
   - 5725 Leesburg Pike
   - Falls Church, VA 22041
-  description: The Fish and Wildlife Service works to conserve, protect and enhance
-    fish, wildlife and plants and their habitats.
+  description: No Description
   emails:
   - fwhq_foia@fws.gov
   fax: 703-358-2251
@@ -357,6 +347,26 @@ departments:
   top_level: true
   usa_id: '48057'
   website: http://www.fws.gov/irm/bpim/foia.html
+- address:
+  - Brian May
+  - FOIA Contact
+  - MS-807, National Center
+  - 12201 Sunrise Valley Drive Room 2B116
+  - Reston, VA 20192
+  emails:
+  - foia@usgs.gov
+  fax: 703-648-7199
+  misc:
+    FOIA Contact: 'Brian May, Phone: (703) 648-7196'
+  name: U.S. Geological Survey
+  notes: This office has additional FOIA contact information that can be found by
+    visiting its website.
+  phone: 703-648-7196
+  public_liaison: 'Joye Durant, Phone: (703) 648-7196'
+  request_form: http://www.doi.gov/foia/foia-request-form.cfm
+  service_center: 'Phone: (703) 648-7196'
+  top_level: false
+  website: http://www.usgs.gov/foia/
 - abbreviation: ''
   address:
   - Charis Wilson
@@ -364,10 +374,7 @@ departments:
   - P.O. Box 25287
   - 12795 W. Alameda Parkway
   - Denver, CO 80225
-  description: The National Park Service cares for the more than 400 national parks
-    in the U.S. The National Park Service also partners with local communities to
-    assist in historic preservaton and the creation and maintenance of recreational
-    spaces.
+  description: No Description
   emails:
   - npsfoia@nps.gov
   fax: 303-969-2557

--- a/contacts/data/DOJ.yaml
+++ b/contacts/data/DOJ.yaml
@@ -77,8 +77,7 @@ departments:
   - Room 1E-400
   - 99 New York Avenue, NE
   - Washington, DC 20226
-  description: The Bureau of Alcohol, Tobacco, Firearms, and Explosives enforces federal
-    criminal laws regulating the firearms and explosives industries.
+  description: No Description
   emails:
   - foiamail@atf.gov
   fax: 202-648-9619
@@ -193,6 +192,22 @@ departments:
   top_level: false
   website: http://www.justice.gov/crt/foia/index.php
 - address:
+  - George Henderson
+  - FOIA/PA Coordinator
+  - Suite 6000
+  - 600 E Street, NW
+  - Washington, DC 20530-0001
+  emails:
+  - CRS.FOIA@usdoj.gov
+  misc:
+    FOIA/PA Coordinator: 'George Henderson, Phone: (202) 305-2935'
+  name: Community Relations Service
+  phone: 202-305-2935
+  public_liaison: 'George Henderson, Phone: (202) 305-2964'
+  service_center: 'Phone: (202) 305-2935'
+  top_level: false
+  website: http://www.justice.gov/crs/foia.htm
+- address:
   - Kenneth Courter
   - Chief, FOIA/PA Unit
   - Suite 1127
@@ -215,9 +230,7 @@ departments:
   - Chief, Freedom of Information/Privacy Act Unit, FOI/Records Management Section
   - 8701 Morrissette Drive
   - Springfield, VA 22152
-  description: The Drug Enforcement Administration enforces the United States' controlled
-    substance laws and regulations and aims to reduce the supply of and demand for
-    such substances.
+  description: No Description
   emails:
   - dea.foia@usdoj.gov
   fax: 202-307-8556
@@ -402,8 +415,7 @@ departments:
   - Room 924, HOLC Building
   - 320 First Street, NW
   - Washington, DC 20534
-  description: The Bureau of Prisons manages federal prisons, and community-based
-    facilities that provide work and opportunities to assist offenders.
+  description: No Description
   emails:
   - ogc_efoia@bop.gov
   keywords:
@@ -498,9 +510,7 @@ departments:
   - 'Two Constitution Square, #11E 1405'
   - 145 N Street, NE
   - Washington, DC 20530-0001
-  description: The Office of Community Oriented Policing Services advances the practice
-    of community policing through sharing information and making grants to police
-    departments in the United States.
+  description: No Description
   emails:
   - COPS.FOIA@usdoj.gov
   fax: 202-514-3456
@@ -769,12 +779,7 @@ departments:
   - FOIA/PA, CS 4, 10th Floor
   - 2604 Jefferson Davis Highway
   - Alexandria, VA 22301
-  description: Part of the Department of Justice, the Marshals Service is responsible
-    for providing security to the federal judiciary, managing the witness security
-    program, managing and selling the seized or forfeited assets of criminals, is
-    responsible for the confinement and transportation of federal prisoners who have
-    not been turned over to the bureau of prisons, and is the primary federal agency
-    responsible for fugitive investigations.
+  description: No Description
   emails:
   - usms.foia@usdoj.gov
   misc:

--- a/contacts/data/DOT.yaml
+++ b/contacts/data/DOT.yaml
@@ -39,7 +39,7 @@ departments:
   - National FOIA Staff (AFN-140)
   - 800 Independence Avenue, SW
   - Washington, DC 20591
-  description: The FAA works to ensure that all air travel is safe.
+  description: No Description
   emails:
   - 7-AWA-ARC-FOIA@faa.gov
   fax: 202-493-5032
@@ -373,14 +373,7 @@ departments:
   - W41-304
   - 1200 New Jersey Avenue, SE
   - Washington, DC 20590
-  description: The National Highway Traffic Safety Administration (NHTSA) is responsible
-    for reducing deaths, injuries and economic losses resulting from motor vehicle
-    crashes. The agency investigates safety defects in motor vehicles, sets and enforces
-    fuel economy standards, helps states and local communities reduce the threat of
-    drunk drivers, promotes the use of safety belts, child safety seats and air bags,
-    investigates odometer fraud, establishes and enforces vehicle anti-theft regulations,
-    conducts research on driver behavior and traffic safety, and provides consumer
-    information on motor vehicle safety topics.
+  description: No Description
   emails:
   - http://www.nhtsa.gov/FOIA
   - greg.walter@dot.gov
@@ -440,6 +433,32 @@ departments:
   - FOIA.Marad@dot.gov
   fax: 202-366-7485
   foia_officer: 'T. Mitchell Hudson, Jr., Phone: (202) 366-5320'
+  keywords:
+  - Administrative practice and procedure
+  - Citizenship and naturalization
+  - Claims
+  - Disability benefits
+  - Fishing vessels
+  - Freight
+  - Government contracts
+  - Grant programs-education
+  - Grant programs-transportation
+  - Highways and roads
+  - Income taxes
+  - Investments
+  - Loan programs-transportation
+  - Maritime carriers
+  - Mortgages
+  - National defense
+  - Passenger vessels
+  - Penalties
+  - Railroads
+  - Reporting and recordkeeping requirements
+  - Schools
+  - Seamen
+  - Trusts and trustees
+  - Uniform System of Accounts
+  - Vessels
   name: Maritime Administration
   phone: 202-366-5320
   public_liaison: 'Ann Herchenrider, Phone: (202) 366-5165'
@@ -536,9 +555,7 @@ departments:
   - FOIA/Privacy Act Officer
   - 395 E Street, SW
   - Washington, DC 20423-0001
-  description: The Surface Transportation Board regulates and decides disputes involving
-    railroad rates, railroad mergers or line sales, and certain other transportation
-    matters.
+  description: No Description
   emails:
   - FOIA.Privacy@stb.dot.gov
   fax: 202-245-0460

--- a/contacts/data/DoD.yaml
+++ b/contacts/data/DoD.yaml
@@ -365,6 +365,23 @@ departments:
   top_level: false
   website: https://www.dss.mil/foia/foia_program.html
 - address:
+  - Juanita Y. Gaines
+  - FOIA/Privacy Act Ofc (JOXGP-F)
+  - MSC 6201
+  - 8725 John J. Kingman Road
+  - Fort Belvoir, VA 22060-6201
+  emails:
+  - efoia@dtra.mil
+  fax: 703-767-3623
+  misc:
+    FOIA/Privacy Act Ofc (JOXGP-F): 'Juanita Y. Gaines, Phone: (703) 767-1771'
+  name: Defense Threat Reduction Agency
+  phone: 703-767-1771
+  public_liaison: 'Richard M. Cole, Phone: (703) 767-5859'
+  service_center: 'Phone: (703) 767-1792'
+  top_level: false
+  website: http://www.dtra.mil/Info/FOIA/FOIAHome.aspx
+- address:
   - Michael A. Hamilton
   - FOIA Contact (DTIC-R)
   - Suite 0944
@@ -421,8 +438,7 @@ departments:
   - Office of Information and Privacy (NGB/JA-OIP)
   - 111 South George Mason Drive, AH2
   - Arlington, VA 22204-1373
-  description: The National Guard assists in times of local emergency and can also
-    be called into federal service.
+  description: No Description
   emails:
   - ng.ncr.arng.mbx.ngb-foia@mail.mil
   fax: 703-607-3684
@@ -441,8 +457,7 @@ departments:
   - 'ATTN: CIO/Information Management Services Office'
   - 14675 Lee Road
   - Chantilly, VA 20151-1715
-  description: The National Reconnaissance Office is responsible for designing, building,
-    launching, and maintaining intelligence satellites.
+  description: No Description
   emails:
   - foia@nro.mil
   - foia@nro.mil
@@ -465,9 +480,7 @@ departments:
   - Suite 6248
   - 9800 Savage Road
   - Fort George G. Meade, MD 20755-6248
-  description: The National Security Agency and Central Security Service are the "codemaker
-    and codebreakers" of the intelligence community, providing foreign signal and
-    communications intelligence to decision makers.
+  description: No Description
   emails:
   - foiarsc@nsa.gov
   - foiarsc@nsa.gov

--- a/contacts/data/ED.yaml
+++ b/contacts/data/ED.yaml
@@ -68,6 +68,7 @@ keywords:
 - Human research subjects
 - Indians-education
 - Individuals with disabilities
+- Inventions and patents
 - Iraq
 - Juvenile delinquency
 - Kuwait

--- a/contacts/data/FMC.yaml
+++ b/contacts/data/FMC.yaml
@@ -18,31 +18,5 @@ departments:
   website: http://www.fmc.gov/about/freedom_of_information_act.aspx
 description: The Commission is responsible for the regulation of ocean-borne transportation
   in the foreign commerce of the U.S.
-keywords:
-- Administrative practice and procedure
-- Authority delegations (Government agencies)
-- Claims
-- Classified information
-- Common carriers
-- Courts
-- Equal access to justice
-- Exports
-- Freedom of information
-- Freight
-- Freight forwarders
-- Government employees
-- Insurance
-- Intermodal transportation
-- Investigations
-- Lawyers
-- Maritime carriers
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Reporting and recordkeeping requirements
-- Seals and insignia
-- Sunshine Act
-- Surety bonds
-- Transportation
 name: Federal Maritime Commission
 usa_id: '52615'

--- a/contacts/data/GSA.yaml
+++ b/contacts/data/GSA.yaml
@@ -1,8 +1,8 @@
 abbreviation: GSA
 common_requests:
 - Federal contracts
-- Purchase card use
 - Government forms
+- Purchase card use
 departments:
 - address:
   - FOIA Contact

--- a/contacts/data/HHS.yaml
+++ b/contacts/data/HHS.yaml
@@ -98,9 +98,7 @@ departments:
   - Suite 920
   - 7700 Wisconsin Avenue
   - Bethesda, MD 20857(if sending by courier use zc 20814)
-  description: The Agency for Healthcare Research and Quality supports research to
-    improve the quality, safety, efficiency, and effectiveness of health care for
-    all Americans.
+  description: No Description
   emails:
   - FOIArequest@psc.hhs.gov
   foia_officer: 'Carol Maloney, Phone: (301) 492-4800 '
@@ -119,10 +117,7 @@ departments:
   - Building 16, D-54
   - 1600 Clifton Road, N.E.
   - Atlanta, GA 30333
-  description: CDC collaborates to create the expertise, information, and tools that
-    people and communities need to protect their health through health promotion,
-    prevention of disease, injury and disability, and preparedness for new health
-    threats.
+  description: No Description
   emails:
   - FOIARequests@cdc.gov
   fax: 404-235-1852
@@ -174,11 +169,7 @@ departments:
   - North Building, Room N2-20-06
   - 7500 Security Boulevard
   - Baltimore, MD 21244
-  description: The Medicare Service Center answers your questions about Medicare topics,
-    manages your orders of Medicare publications, provides detailed information about
-    the Medicare managed care plans in your area, shares Medicare health plan quality
-    and customer satisfaction information. Contact the Center to obtain the phone
-    number to your state Medicaid office.
+  description: No Description
   fax: 410-786-0474
   foia_officer: 'Michael Marquis, Phone: (410) 786-5353'
   keywords:
@@ -268,10 +259,7 @@ departments:
   - Room 1020
   - 12420 Parklawn Drive
   - Rockville, MD 20857
-  description: The FDA is responsible for protecting the public health by assuring
-    the safety, efficacy, and security of human and veterinary drugs, biological products,
-    medical devices, our nations food supply, cosmetics, and products that emit radiation.
-    The FDA also provides accurate, science-based health information to the public.
+  description: No Description
   fax: 301-827-9267
   keywords:
   - Adhesives
@@ -377,8 +365,7 @@ departments:
   - Parklawn Building, Room 6C-18
   - 5600 Fishers Lane
   - Rockville, MD 20857
-  description: The Health Resources and Services Administration improves access to
-    healthcare for people who are uninsured, isolated, or medically vulnerable.
+  description: No Description
   emails:
   - foia@hrsa.gov
   fax: 301-480-5285
@@ -419,8 +406,7 @@ departments:
   - Suite 450 TMP
   - 801 Thompson Avenue
   - Rockville, MD 20852
-  description: The Indian Health Service provides federal health services to American
-    Indians and Alaska Natives.
+  description: No Description
   fax: 301-443-9879
   foia_officer: 'William Tibbits, Phone: (301) 443-1116'
   keywords:
@@ -454,8 +440,7 @@ departments:
   - Building 31, Room 5B35
   - 9000 Rockville Pike
   - Bethesda, MD 20892
-  description: The National Institutes of Health (NIH) is the primary Federal agency
-    for conducting and supporting medical research.
+  description: No Description
   fax: 301-402-4541
   foia_officer: 'Susan Cornell, Phone: (301) 496-5633'
   keywords:
@@ -498,9 +483,7 @@ departments:
   - Room 8-1042
   - 1 Choke Cherry Road
   - Rockville, MD 20857
-  description: Through grants and research, the Substance Abuse and Mental Health
-    Services Administration works to improve substance abuse and mental health treatment
-    services to those who are most in need of them.
+  description: No Description
   emails:
   - foia@samhsa.hhs.gov
   fax: 240-276-2135

--- a/contacts/data/NLRB.yaml
+++ b/contacts/data/NLRB.yaml
@@ -1,8 +1,8 @@
 abbreviation: NLRB
 departments:
 - address:
-  - Eric G. Moskowitz
-  - Acting FOIA Officer
+  - Deirdre MacNeil
+  - FOIA Officer
   - Room 10600
   - 1099 14th Street, NW
   - Washington, DC  20570
@@ -11,10 +11,10 @@ departments:
   name: National Labor Relations Board
   notes: This agency has additional FOIA contact information that can be found by
     visiting its website.
-  phone: 202-273-2931
-  public_liaison: 'Jayme Sophir, Phone: (202) 273-3800'
-  request_form: http://www.nlrb.gov/e-foia-request-form
-  service_center: 'Phone: (202) 273-1991'
+  phone: 202-273-3840
+  public_liaison: 'Diane Bridge, Phone: (202) 273-3851'
+  request_form: http://www.nlrb.gov/news-outreach/foia/e-foia-request-form
+  service_center: 'Phone: (202) 273-3843'
   top_level: false
   website: http://www.nlrb.gov/FOIA/
 description: The National Labor Relations Board is an independent federal agency that

--- a/contacts/data/OSTP.yaml
+++ b/contacts/data/OSTP.yaml
@@ -1,6 +1,6 @@
 abbreviation: OSTP
 common_requests:
-- Records on OSTP's scientific advice and correspondence.
+- Records on OSTP's scientific advice and correspondance.
 departments:
 - address:
   - Rachael Leonard
@@ -26,5 +26,5 @@ keywords:
 - white house
 name: Office of Science and Technology Policy
 no_records_about:
-- General White House correspondence or documents.
+- General White House correspondance or documents.
 usa_id: '49590'

--- a/contacts/data/PC.yaml
+++ b/contacts/data/PC.yaml
@@ -23,29 +23,6 @@ departments:
   - Washington, DC 20536-0001
   emails:
   - foia@peacecorps.gov
-  keywords:
-  - Administrative practice and procedure
-  - Civil rights
-  - Computer technology
-  - Education of disadvantaged
-  - Emergency medical services
-  - Fraud
-  - Grant programs-health
-  - Grant programs-social programs
-  - Health care
-  - Health facilities
-  - Health insurance
-  - Health maintenance organizations (HMO)
-  - Health professions
-  - Health records
-  - Hospitals
-  - Maternal and child health
-  - Medicaid
-  - Medicare
-  - Penalties
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Social security
   misc:
     FOIA Contact: 'Jeffrey Reichert, Phone: (202) 692-2922'
   name: Office of the Inspector General

--- a/contacts/data/Treasury.yaml
+++ b/contacts/data/Treasury.yaml
@@ -27,8 +27,7 @@ departments:
   - Box 12
   - 1310 G Street, NW
   - Washington, DC 20220
-  description: The Alcohol and Tobacco Tax and Trade Bureau collects taxes and enforces
-    regulations on alcohol, tobacco, firearms, and ammunition.
+  description: No Description
   emails:
   - ttbfoia@ttb.gov
   fax: 202-453-2331
@@ -103,9 +102,7 @@ departments:
   - 419 A
   - Office of the Chief Counsel FOIA & Transparency 14th & C Street, SW
   - Washington, DC 20228
-  description: The Bureau of Engraving and Printing produces United States currency
-    notes, operates as the nation's central bank, and serves to ensure that adequate
-    amounts of currency and coin are in circulation.
+  description: No Description
   fax: 202-874-2951
   keywords:
   - Currency
@@ -278,7 +275,6 @@ departments:
   - Federal Reserve System
   - Firefighters
   - Flags
-  - Foreign banking
   - Forgery
   - Fraud
   - Freedom of information
@@ -286,8 +282,6 @@ departments:
   - Government employees
   - Government property
   - Government securities
-  - Grant programs
-  - Housing
   - Income taxes
   - Insurance
   - Insurance companies
@@ -327,11 +321,11 @@ departments:
   top_level: false
   website: http://www.fms.treas.gov/foia/index.html
 - address:
-  - Disclosure Manager
   - FOIA Contact
   - HQ FOIA Stop 211
-  - 'HQ & FOIA Operations ATTn: IRS FOIA Request 2980 Brandywine Road'
-  - Chamblee, GA 30341
+  - PO Box 621506
+  - Atlanta, GA 30362-3006
+  fax: 877-807-9215
   keywords:
   - Accounting
   - Administrative practice and procedure
@@ -401,11 +395,11 @@ departments:
   name: Internal Revenue Service - Headquarters Office
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
-  phone: 202-317-3475
+  phone: (202) 317-3475
   public_liaison: 'Phone: (202) 317-3475'
   service_center: 'Phone: (202) 317-3475'
   top_level: false
-  website: http://www.irs.gov/foia/article/0,,id=120681,00.html
+  website: http://www.irs.gov/uac/IRS-Freedom-of-Information
 - abbreviation: ''
   address:
   - Kathleen Saunders-Mitchell
@@ -413,8 +407,7 @@ departments:
   - 8th Floor
   - 801 9th Street, NW
   - Washington, DC 20220
-  description: The Mint produces the the coins that circulate throughout the US. They
-    also produce special edition coinage that can be purchased for coin collections.
+  description: No Description
   fax: 202-756-6153
   misc:
     FOIA Contact: 'Kathleen Saunders-Mitchell, Phone: (202) 354-4600'

--- a/contacts/data/U.S. DOL.yaml
+++ b/contacts/data/U.S. DOL.yaml
@@ -21,10 +21,7 @@ departments:
   - Room S-5317
   - 200 Constitution Avenue, NW
   - Washington, DC 20210-001
-  description: The Bureau of International Labor Affairs works to improve working
-    conditions, raise living standards, protect workers’ ability to exercise their
-    rights, and address the workplace exploitation of children and other vulnerable
-    populations.
+  description: No Description
   emails:
   - ILABFOIA@dol.gov
   name: Bureau of International Labor Affairs
@@ -40,8 +37,7 @@ departments:
   - Room 4080 Postal Square Building
   - 2 Massachusetts Avenue, NE
   - Washington, DC 20212-0001
-  description: The Bureau of Labor Statistics measures labor market activity, working
-    conditions, and price changes in the economy.
+  description: No Description
   fax: 202-691-5111
   name: Bureau of Labor Statistics
   phone: 202-691-7628
@@ -57,8 +53,7 @@ departments:
   - Public Disclosure Room, Suite N-1513
   - 200 Constitution Avenue, NW
   - Washington, DC 20210
-  description: The EBSA provides information and assistance on private sector, employer-sponsored
-    retirement benefit and health benefit plans.
+  description: No Description
   emails:
   - foiarequest@dol.gov
   keywords:
@@ -110,8 +105,7 @@ departments:
   - FOIA Disclosure Officer
   - 200 Constitution Avenue, NW
   - Washington, DC 20210-0002
-  description: The Employment and Training Administration provides job training and
-    assistance with finding jobs and careers.
+  description: No Description
   fax: 202-693-2844
   keywords:
   - Accounting
@@ -206,9 +200,7 @@ departments:
   - Room 2314
   - 1100 Wilson Boulevard
   - Arlington, VA 22209-3939
-  description: The Mine Safety and Health Administration works to prevent mining related
-    deaths, injuries, and illnesses through mine regulations, inspections, and training
-    programs.
+  description: No Description
   emails:
   - foiarequest@dol.gov
   fax: 202-963-9441
@@ -402,9 +394,7 @@ departments:
   - Room N3647
   - 200 Constitution Avenue, NW
   - Washington, DC 20210
-  description: The Occupational Safety and Health Administration (OSHA) assures safe
-    and healthful working conditions for working men and women by setting and enforcing
-    standards, and by providing training, outreach, education and assistance.
+  description: No Description
   fax: 202-693-1635
   keywords:
   - Administrative practice and procedure

--- a/contacts/data/USAID.yaml
+++ b/contacts/data/USAID.yaml
@@ -40,6 +40,8 @@ keywords:
 - Educational facilities
 - Educational research
 - Educational study programs
+- Environmental impact statements
+- Environmental protection
 - Equal educational opportunity
 - Equal employment opportunity
 - Federal buildings and facilities

--- a/contacts/data/USDA.yaml
+++ b/contacts/data/USDA.yaml
@@ -424,6 +424,30 @@ departments:
   top_level: false
   website: http://www.fsis.usda.gov/FOIA/index.asp
 - address:
+  - Henry Noland
+  - FOIA Officer
+  - Stop 1004
+  - 1400 Independence Avenue, SW
+  - Washington, DC 20250-1004
+  emails:
+  - Henry.Noland@fas.usda.gov
+  foia_officer: 'Henry Noland, Phone: (202) 720-0154'
+  keywords:
+  - Agricultural commodities
+  - Exports
+  - Food assistance programs
+  - Foreign aid
+  - Government procurement
+  - Imports
+  - Reporting and recordkeeping requirements
+  - Trade adjustment assistance
+  name: Foreign Agricultural Service
+  phone: 202-720-0154
+  public_liaison: 'Sally Klusaritz, Phone: (202) 720-3448'
+  service_center: 'Phone: (202) 720-3101'
+  top_level: false
+  website: http://www.fas.usda.gov/info/FOIA/freedom.asp
+- address:
   - Sherry Turner
   - 'FOIA/PA Officer - ATTN: FOIA/PA Team'
   - Stop 1143

--- a/contacts/data/USITC.yaml
+++ b/contacts/data/USITC.yaml
@@ -22,16 +22,5 @@ description: The mission of the Commission is to (1) administer U.S. trade remed
   USTR, and Congress with independent analysis, information, and support on matters
   of tariffs, international trade, and U.S. competitiveness; and (3) maintain the
   Harmonized Tariff Schedule of the United States (HTS).
-keywords:
-- Administrative practice and procedure
-- Australia
-- Business and industry
-- Canada
-- Customs duties and inspection
-- Imports
-- Investigations
-- Mexico
-- Reporting and recordkeeping requirements
-- Trade agreements
 name: United States International Trade Commission
 usa_id: '49712'

--- a/contacts/data/VA.yaml
+++ b/contacts/data/VA.yaml
@@ -195,6 +195,23 @@ departments:
   top_level: false
   website: http://www.foia.va.gov/
 - address:
+  - Laurie Karnay
+  - FOIA Team Lead
+  - (005R1C) VACO
+  - 810 Vermont Avenue, NW
+  - Washington, DC 20420
+  emails:
+  - vacofoiaservice@va.gov
+  fax: 202-632-7581
+  misc:
+    FOIA Team Lead: 'Laurie Karnay, Phone: (202) 632-7465'
+  name: Office of Assistant Secretary for Information and Technology
+  phone: 202-632-7465
+  public_liaison: 'James Horan, Phone: (877) 750-3642'
+  service_center: 'Phone: (877) 750-3642'
+  top_level: false
+  website: http://www.foia.va.gov/
+- address:
   - Yolanda Johnson
   - FOIA Contact
   - (006V) VACO

--- a/contacts/layer_with_csv.py
+++ b/contacts/layer_with_csv.py
@@ -11,7 +11,6 @@ from urllib.request import urlopen
 import xlrd
 import yaml
 
-FIX_AGENCY_NAME = re.compile("\s+$")
 
 def address_lines(row):
     """Convert a row of dictionary data into a list of address lines"""
@@ -38,7 +37,7 @@ def contact_string(row):
 
 def add_contact_info(contacts, row):
     """Process a row of the xls, adding data to the contacts dictionary"""
-    agency, office = row['Department'], FIX_AGENCY_NAME.sub('',row['Agency'])
+    agency, office = row['Department'], row['Agency'].strip()
 
     if agency not in contacts:
         contacts[agency] = {}

--- a/contacts/layer_with_csv.py
+++ b/contacts/layer_with_csv.py
@@ -5,11 +5,13 @@ from copy import deepcopy
 from glob import glob
 import logging
 import os
+import re
 from urllib.request import urlopen
 
 import xlrd
 import yaml
 
+FIX_AGENCY_NAME = re.compile("\s+$")
 
 def address_lines(row):
     """Convert a row of dictionary data into a list of address lines"""
@@ -36,7 +38,8 @@ def contact_string(row):
 
 def add_contact_info(contacts, row):
     """Process a row of the xls, adding data to the contacts dictionary"""
-    agency, office = row['Department'], row['Agency']
+    agency, office = row['Department'], FIX_AGENCY_NAME.sub('',row['Agency'])
+
     if agency not in contacts:
         contacts[agency] = {}
     if office not in contacts[agency]:

--- a/contacts/tests.py
+++ b/contacts/tests.py
@@ -367,6 +367,13 @@ class LayerTests(TestCase):
         self.assertTrue("ACRONYM" in contact_dict)
         self.assertTrue("Sewage Treatment" in contact_dict["ACRONYM"])
         self.assertTrue("Road Maintenance" in contact_dict["ACRONYM"])
+        #   Adding another agency with leading and trailing spaces
+        row["Agency"] = "  Economic Development   "
+        layer.add_contact_info(contact_dict, row)
+        self.assertTrue("ACRONYM" in contact_dict)
+        self.assertTrue("Sewage Treatment" in contact_dict["ACRONYM"])
+        self.assertTrue("Road Maintenance" in contact_dict["ACRONYM"])
+        self.assertTrue("Economic Development" in contact_dict["ACRONYM"])
 
     def test_add_contact_info_website(self):
         """Website field gets cleaned up -- verify it's not added unless it's


### PR DESCRIPTION
This should fix [Issue 149](https://github.com/18F/foia-hub/issues/149)

Turns out that the Economic Development Administration wasn't loading because it had an extra space in the full-foia-contact.xls file as in "Economic Development Administration ". 

The [file](http://www.foia.gov/full-foia-contacts.xls) is hosted on foia.gov so I opted for the regex solution instead of fixing the file. If anyone has a contact, I can email them if needed. 
