### PR TITLE
Sync contributing instructions with foia-hub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,16 @@
-## Day to day work
+## Team Processes
 
-* Use PEP8 as the coding standard for Python. 
+* Use PEP8 as the coding standard for Python.
+* Pull requests for all commits, even typos.
+* Don't merge your own pull request. Find a friend to review your code and merge your pull request.
+* Pull requests some contain some tests. Ideally they would contain decent test coverage.
 
-* Pull requests for all commits (even small, minor commits)
-* Don't merge your own pull request. Find a friend to review your code and merge your pull request. 
-* Pull requests some contain some tests. Ideally they would contain decent test coverage. 
+When creating a new pull request:
+
+* If the pull request is still a work-in-progress and should not be merged, say so in the description and then **assign the PR to yourself**. When the PR is ready to be merged, **unassign yourself and add a comment**.
+* If a new pull request is ready for review, **leave it unassigned**. This is the assumed state of new PRs, but work-in-progress PRs are quite welcome.
+* If you decide to review a pull request with the intent of merging it (or deciding what still needs to be done before merge), then **assign the PR to yourself** so that it's clear that someone's grabbed it.
+* Anyone is welcome to informally review a PR and comment on it at any time, no matter who is assigned.
 
 ## Public domain
 


### PR DESCRIPTION
Uses the new PR guidelines from foia-hub.
