### PR TITLE
Keyword fix

### DIFF
--- a/contacts/data/DHS.yaml
+++ b/contacts/data/DHS.yaml
@@ -40,10 +40,15 @@ departments:
   - Administrative practice and procedure
   - Aliens
   - Authority delegations (Government agencies)
+  - Employment
+  - Foreign officials
   - Freedom of information
+  - Health professions
   - Immigration
+  - Penalties
   - Privacy
   - Reporting and recordkeeping requirements
+  - Students
   - Surety bonds
   name: U.S. Citizenship & Immigration Services
   notes: This office has additional FOIA contact information that can be found by

--- a/contacts/data/DoD.yaml
+++ b/contacts/data/DoD.yaml
@@ -39,6 +39,9 @@ departments:
   fax: 703-696-7273
   keywords:
   - Administrative practice and procedure
+  - Air carriers
+  - Alimony
+  - Aviation safety
   - Child support
   - Civil defense
   - Civil disorders

--- a/contacts/data/DoD.yaml
+++ b/contacts/data/DoD.yaml
@@ -39,9 +39,6 @@ departments:
   fax: 703-696-7273
   keywords:
   - Administrative practice and procedure
-  - Air carriers
-  - Alimony
-  - Aviation safety
   - Child support
   - Civil defense
   - Civil disorders

--- a/contacts/data/FHFA.yaml
+++ b/contacts/data/FHFA.yaml
@@ -52,6 +52,7 @@ keywords:
 - Holding companies
 - Housing
 - Insurance
+- Intergovernmental relations
 - Investments
 - Minority businesses
 - Mortgages
@@ -65,6 +66,7 @@ keywords:
 - Seals and insignia
 - Securities
 - Sunshine Act
+- Trade practices
 - Truth in lending
 - Wages
 name: Federal Housing Finance Agency

--- a/contacts/keywords_from_fr.py
+++ b/contacts/keywords_from_fr.py
@@ -85,6 +85,15 @@ def normalize_name(name):
     return name.strip()
 
 
+def normalize_and_map(keywords):
+    new_dictionary = dict()
+    for key in keywords.keys():
+        normal_key = normalize_name(key)
+        new_dictionary[normal_key] = \
+            keywords.get(key,[]) | set(new_dictionary.get(normal_key,[]))
+    return new_dictionary
+
+
 def add_results(results, keywords):
     """Add entries found in the results to the dictionary of keywords"""
     for result in results['results']:
@@ -158,9 +167,8 @@ def new_keywords(agency_data, fr_keywords):
 def patch_yaml():
     """Go through the YAML files; for all agencies, check if we have some new
     keywords based on FR data. If so, update the YAML"""
-    fr_keywords = build_keywords()
-    fr_keywords = {normalize_name(name): value
-                   for name, value in fr_keywords.items()}
+    fr_keywords = normalize_and_map(build_keywords())
+
     for filename in glob("data" + os.sep + "*.yaml"):
         num_new_keywords = 0
         with open(filename) as f:

--- a/contacts/keywords_from_fr.py
+++ b/contacts/keywords_from_fr.py
@@ -86,6 +86,8 @@ def normalize_name(name):
 
 
 def normalize_and_map(keywords):
+    """Maps old dictionary to dictionary with new keys without loosing
+    keys in the process """
     new_dictionary = dict()
     for key in keywords.keys():
         normal_key = normalize_name(key)

--- a/contacts/tests.py
+++ b/contacts/tests.py
@@ -555,6 +555,11 @@ class FRTests(TestCase):
         self.assertEqual(29, fr.last_day_in_month(2004, 2))
         self.assertEqual(31, fr.last_day_in_month(2011, 1))
 
+    def test_normalize_and_map(self):
+        """should normalize keys w/ loosing data"""
+        test_dict = {'A':{'datum1'},'B':{'datum2'},'a':{'datum3'}}
+        expected_dict = {'A':{'datum1','datum3'},'B':{'datum2'}}
+        self.assertEqual(expected_dict,fr.normalize_and_map(test_dict))
 
 class USALayerTests(TestCase):
     def test_float_to_int_str(self):


### PR DESCRIPTION
Makes keywords download consistent. 

I think the issue was that some names became duplicates after normalization and once they were put into a dictionary only the last value was saved. 

``` python
fr_keywords = {normalize_name(name): value
                   for name, value in fr_keywords.items()}
```
