### PR TITLE
Removed foia-design link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This repo is for project-wide [discussion](https://github.com/18f/foia/issues) f
 
 Also see:
 
-* [foia-design](https://github.com/18F/foia-design) - Where our FOIA hub designs and mockups are located. 
-* [foia-hub](https://github.com/18F/foia-hub) - Core interaction between FOIA requestor and FOIA office. Includes what was previously contained in FOIA core. (Static website + Python 3 / Flask)
+* [foia-hub](https://github.com/18F/foia-hub) - Core interaction between FOIA requestor and FOIA office. Includes what was previously contained in FOIA core and FOIA design. (Static website + Python 3 / Flask)
 * [foia-search](https://github.com/18F/foia-search) - A search/similarity/discovery API over information from FOIA responses. (Node / Elasticsearch)
 
 ## Public domain


### PR DESCRIPTION
FOIA design just pointed back to FOIA-hub, so didn't seem worthwhile to include.
