### PR TITLE
Gracefully handle too_many_redirects and other reading room changes. 

### DIFF
--- a/contacts/data/DOJ.yaml
+++ b/contacts/data/DOJ.yaml
@@ -1184,6 +1184,10 @@ departments:
   reading_rooms:
   - - FOIA Library
     - http://www.justice.gov/usao/resources/foialibrary/
+  - - FOIA Library
+    - http://www.justice.gov/usao/foia-library
+  - - FOIA Library
+    - http://www.justice.gov/usao/resources/foialibrary
   request_time_stats:
     '2008':
       expedited_processing_average_days: '641.48'
@@ -2726,6 +2730,10 @@ departments:
   reading_rooms:
   - - FOIA Library
     - http://www.justice.gov/usao/resources/foialibrary/
+  - - FOIA Library
+    - http://www.justice.gov/usao/foia-library
+  - - FOIA Library
+    - http://www.justice.gov/usao/resources/foiarequests/../foialibrary
   service_center: 'Phone: (202) 252-6020'
   top_level: false
   website: http://www.justice.gov/usao/resources/foiarequests/

--- a/contacts/data/DOJ.yaml
+++ b/contacts/data/DOJ.yaml
@@ -1184,10 +1184,6 @@ departments:
   reading_rooms:
   - - FOIA Library
     - http://www.justice.gov/usao/resources/foialibrary/
-  - - FOIA Library
-    - http://www.justice.gov/usao/foia-library
-  - - FOIA Library
-    - http://www.justice.gov/usao/resources/foialibrary
   request_time_stats:
     '2008':
       expedited_processing_average_days: '641.48'
@@ -2730,10 +2726,6 @@ departments:
   reading_rooms:
   - - FOIA Library
     - http://www.justice.gov/usao/resources/foialibrary/
-  - - FOIA Library
-    - http://www.justice.gov/usao/foia-library
-  - - FOIA Library
-    - http://www.justice.gov/usao/resources/foiarequests/../foialibrary
   service_center: 'Phone: (202) 252-6020'
   top_level: false
   website: http://www.justice.gov/usao/resources/foiarequests/

--- a/contacts/data/DOJ.yaml
+++ b/contacts/data/DOJ.yaml
@@ -1184,6 +1184,8 @@ departments:
   reading_rooms:
   - - FOIA Library
     - http://www.justice.gov/usao/resources/foialibrary/
+  - - FOIA Library
+    - http://www.justice.gov/usao/foia-library
   request_time_stats:
     '2008':
       expedited_processing_average_days: '641.48'
@@ -2726,6 +2728,10 @@ departments:
   reading_rooms:
   - - FOIA Library
     - http://www.justice.gov/usao/resources/foialibrary/
+  - - FOIA Library
+    - http://www.justice.gov/usao/foia-library
+  - - FOIA Library
+    - http://www.justice.gov/usao/resources/foiarequests/../foialibrary
   service_center: 'Phone: (202) 252-6020'
   top_level: false
   website: http://www.justice.gov/usao/resources/foiarequests/

--- a/contacts/layer_with_reading_room.py
+++ b/contacts/layer_with_reading_room.py
@@ -49,7 +49,6 @@ def get_absolute_url(link, url):
         if domains_match(url, href):
             return [clean_link_text(link.text), href]
 
-
 def unique_links(links):
     """ We sometimes get the same URI with different link texts. Squash those.
     """
@@ -71,9 +70,7 @@ def unique_links(links):
             # Ignore the link, as it clearly doesn't work.
             pass
 
-    seen = set()
-    uniques = [l for l in redirected
-               if l[1] not in seen and not seen.add(l[1])]
+    uniques = uniquefy(redirected)
     return uniques
 
 
@@ -117,8 +114,12 @@ def process(data):
 
 def uniquefy(links):
     seen = set()
-    uniques = [l for l in links
-               if l[1] not in seen and not seen.add(l[1])]
+    uniques = []
+    for link in links:
+        l = link[1].rstrip('/')
+        if l not in seen:
+            seen.add(l)
+            uniques.append(link)
     return uniques
 
 

--- a/contacts/layer_with_reading_room.py
+++ b/contacts/layer_with_reading_room.py
@@ -132,7 +132,6 @@ def update_links(agency_data, links):
     unique_links = uniquefy(all_links)
     sorted_uniques = sorted(unique_links, key=lambda x: x[0])
 
-
     agency_data['reading_rooms'] = sorted_uniques
     return agency_data
 

--- a/contacts/layer_with_reading_room.py
+++ b/contacts/layer_with_reading_room.py
@@ -67,6 +67,9 @@ def unique_links(links):
         except requests.exceptions.ConnectionError:
             # Ignore the link, as it clearly doesn't work.
             pass
+        except requests.exceptions.TooManyRedirects:
+            # Ignore the link, as it clearly doesn't work.
+            pass
 
     seen = set()
     uniques = [l for l in redirected

--- a/contacts/tests/reading_room_tests.py
+++ b/contacts/tests/reading_room_tests.py
@@ -97,3 +97,16 @@ class ReadingRoomTests(TestCase):
                 ['Reading Room', 'http://gsa.gov/foia/reading-room'],
                 ['FOIA Library', 'http://gsa.gov/foia/library']],
             links)
+
+    def test_remove_same_urls(self):
+        links = [
+            ['text one', 'http://testone.gov'],
+            ['text two', 'http://testone.gov']]
+        uniques = reading.uniquefy(links)
+        self.assertEqual(len(uniques), 1)
+
+        links = [
+            ['text one', 'http://testone.gov/resources/foialibrary/'],
+            ['text two', 'http://testone.gov/resources/foialibrary']]
+        uniques = reading.uniquefy(links)
+        self.assertEqual(len(uniques), 1)


### PR DESCRIPTION
This pull requests does a few things:
- Gracefully handles a too_many_redirects exception (which I've been unable to recreate) by ignoring it
- The function that determines that two urls are the same, wasn't quite working correctly - so an update is provided to that logic
- Incidentally, some DOJ urls got updated (which also prompted the change above). 
- Some PEP8 related changes. 
