### PR TITLE
Changes to reading room scraping code (better domain matching, better redirect handling)

### DIFF
--- a/contacts/data/CIA.yaml
+++ b/contacts/data/CIA.yaml
@@ -9,6 +9,9 @@ departments:
   name: Central Intelligence Agency
   phone: 703-613-1287
   public_liaison: 'Scott Koch, Michele Meeks, Phone: (703) 613-1287'
+  reading_rooms:
+  - - Freedom of Information Act Electronic Reading Room
+    - http://www.foia.cia.gov/
   request_form: http://www.foia.cia.gov/foia_request/form
   service_center: 'Phone: (703) 613-1287'
   top_level: false

--- a/contacts/tests/tests.py
+++ b/contacts/tests/tests.py
@@ -136,7 +136,7 @@ class ScraperTests(TestCase):
 
         applied = scraper.actual_apply(agency_data, manual_data)
 
-        #new keywords added, but emails overwritten
+        # New keywords added, but emails overwritten.
         self.assertEqual(
             applied['emails'],
             ['public.liaison@agency.gov'])
@@ -684,7 +684,7 @@ class ProcessingTimeScaperTests(TestCase):
     def test_get_years(self):
         """ Verify that the correct years are retrieved """
 
-        years = processing_time_scraper. get_years()
+        years = processing_time_scraper.get_years()
         years = sorted(years)
         self.assertEqual(['2008', '2009', '2010', '2011'], years[0:4])
 


### PR DESCRIPTION
The CIA landing page had no reading room links. This turned out because the reading room code needed some changes. Those changes are below. Namely domains are matched more accurately using second level domains. Also, 302 redirects are handled more gracefully. 

There's also some PEP8 and syntax related clean up. 

This PR fixes: https://github.com/18F/foia-hub/issues/309
