### PR TITLE
eucom update

### DIFF
--- a/contacts/data/DoD.yaml
+++ b/contacts/data/DoD.yaml
@@ -2111,7 +2111,7 @@ departments:
   - Unit 30400
   - APO, AE 09131
   emails:
-  - whs.mc-alex.esd.mbx.foia-liaison@mail.mil
+  - eucom.stuttgart.ecj1.list.foia-privact-request-mb-access@mail.mil
   fax: +49011 711-680-8092
   misc:
     HQ USEUCOM: 'FOIA Contact, Phone: 49 011 711 680-7161'

--- a/contacts/manual_data/DoD.yaml
+++ b/contacts/manual_data/DoD.yaml
@@ -34,7 +34,7 @@ departments:
   website: http://www.centcom.mil/en/freedom-of-information-act-en
 - name: U.S. European Command
   emails:
-  - whs.mc-alex.esd.mbx.foia-liaison@mail.mil
+  - eucom.stuttgart.ecj1.list.foia-privact-request-mb-access@mail.mil
   website: http://www.eucom.mil/policies-and-compliance/freedom-of-information-act-foia-requestor-service-center
 - name: U.S. Northern Command
   emails:


### PR DESCRIPTION
A month ago DOD said to replace `foiarequest@eucom.mil` with `whs.mc-alex.esd.mbx.foia-liaison@mail.mil` but it seems that emails are changing again. The EUCOM liaison gave me an update and let me know that the DOJ will soon have an updated contact list. 
