### PR TITLE
adding missing addresses and public liaison numbers.

### DIFF
--- a/contacts/data/CIA.yaml
+++ b/contacts/data/CIA.yaml
@@ -1,6 +1,14 @@
 abbreviation: CIA
 departments:
-- fax: 703-613-3007
+- address:
+    address_lines:
+    - Information and Privacy Coordinator
+    - Central Intelligence Agency
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20505'
+  fax: 703-613-3007
   name: Central Intelligence Agency
   phone: 703-613-1287
   public_liaison:

--- a/contacts/data/DHS.yaml
+++ b/contacts/data/DHS.yaml
@@ -1261,7 +1261,15 @@ departments:
     - 202-254-4001
   top_level: false
   website: http://www.dhs.gov/xfoia/editorial_0788.shtm
-- emails:
+- address:
+    address_lines:
+    - 'FOIA: Office of Intelligence & Analysis'
+    - U.S. Department of Homeland Security
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20528'
+  emails:
   - I&AFOIA@hq.dhs.gov
   fax: 202-612-1936
   foia_officer:
@@ -1346,7 +1354,15 @@ departments:
     - 202-282-8191
   top_level: false
   website: http://www.dhs.gov/xfoia/gc_1294073392661.shtm
-- emails:
+- address:
+    address_lines:
+    - 'FOIA: Directorate for National Protection and Programs'
+    - U.S. Department of Homeland Security
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20528'
+  emails:
   - NPPD.FOIA@dhs.gov
   fax: 703-235-2052
   foia_officer:
@@ -1436,7 +1452,15 @@ departments:
     - 703-235-2211
   top_level: false
   website: http://www.dhs.gov/xabout/structure/editorial_0794.shtm
-- emails:
+- address:
+    address_lines:
+    - 'FOIA: Office of Operations Coordination and Planning'
+    - U.S. Department of Homeland Security
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20528'
+  emails:
   - FOIAOPS@DHS.GOV
   fax: 202-282-9811
   foia_officer:

--- a/contacts/data/DOC.yaml
+++ b/contacts/data/DOC.yaml
@@ -48,8 +48,6 @@ departments:
   reading_rooms:
   - - FOIA Library
     - http://www.census.gov/foia/foia_library/
-  - - FOIA Library
-    - http://www.census.gov/about/policies/foia/foia_library.html
   request_form: http://www.census.gov/foia/foia_request.php
   request_time_stats:
     '2008':

--- a/contacts/data/DOI.yaml
+++ b/contacts/data/DOI.yaml
@@ -1437,6 +1437,8 @@ departments:
   phone: 505-816-1645
   public_liaison:
     name: Veronica Herkshan
+    phone:
+    - 505-816-1645
   request_form: http://www.doi.gov/foia/foia-request-form.cfm
   service_center:
     phone:

--- a/contacts/data/HHS.yaml
+++ b/contacts/data/HHS.yaml
@@ -209,6 +209,14 @@ departments:
   top_level: false
   website: http://oig.hhs.gov/foia/
 - abbreviation: ACL
+  address:
+    address_lines:
+    - FOIA Requester Service Center
+    - Administration for Community Living
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20201'
   description: ACL brings together the efforts and achievements of the Administration
     on Aging, the Administration on Intellectual and Developmental Disabilities, and
     the HHS Office on Disability to serve as the Federal agency responsible for increasing

--- a/contacts/data/NASA.yaml
+++ b/contacts/data/NASA.yaml
@@ -1095,7 +1095,14 @@ departments:
     - 228-813-6174
   top_level: true
   website: http://www.nssc.nasa.gov/foia/
-- emails:
+- address:
+    address_lines:
+    - 'FOIA: Sally Blibo'
+    city: Stennis Space Center
+    state: MS
+    street: Building 1100 room 304D
+    zip: '39529'
+  emails:
   - ssc-foia@nasa.gov
   fax: 228-668-7499
   foia_officer:

--- a/contacts/data/ODNI.yaml
+++ b/contacts/data/ODNI.yaml
@@ -1,6 +1,15 @@
 abbreviation: DNI
 departments:
-- emails:
+- address:
+    address_lines:
+    - Jennifer L. Hudson
+    - Director, Information Management Division
+    - Office of the Director of National Intelligence
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20511'
+  emails:
   - dni-foia@dni.gov
   fax: 703-874-8910
   misc:

--- a/contacts/data/U.S. DOL.yaml
+++ b/contacts/data/U.S. DOL.yaml
@@ -1654,7 +1654,16 @@ departments:
     - 202-693-4700
   top_level: false
   website: http://www.dol.gov/vets/foia/
-- keywords:
+- address:
+    address_lines:
+    - 'FOIA: Wage and Hour Division'
+    - U. S. Department of Labor
+    - Room S-3201
+    city: Washington
+    state: DC
+    street: 200 Constitution Avenue, N.W.
+    zip: '20210'
+  keywords:
   - Administrative practice and procedure
   - Agricultural commodities
   - Agriculture

--- a/contacts/data/USDA.yaml
+++ b/contacts/data/USDA.yaml
@@ -1245,7 +1245,9 @@ departments:
   name: National Finance Center
   phone: 504-426-0168
   public_liaison:
-    name: Patricia Blumenthal
+    name: Shri Alsobrook, Sandy Francois
+    phone:
+    - 504-426-0327
   reading_rooms:
   - - Click here to access the NFC Electronic Reading Room
     - https://www.nfc.usda.gov/FOIA/foiaereading.html

--- a/contacts/manual_data/CIA.yaml
+++ b/contacts/manual_data/CIA.yaml
@@ -1,5 +1,13 @@
 departments:
-- name: Central Intelligence Agency
+- address:
+    address_lines:
+    - Information and Privacy Coordinator
+    - Central Intelligence Agency
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20505'
+  name: Central Intelligence Agency
   request_form: http://www.foia.cia.gov/foia_request/form
 keywords:
 - spies

--- a/contacts/manual_data/DHS.yaml
+++ b/contacts/manual_data/DHS.yaml
@@ -27,11 +27,35 @@ departments:
   request_form: http://www.dhs.gov/dhs-foia-request-submission-form
 - name: Office of the Inspector General
   request_form: http://www.dhs.gov/dhs-foia-request-submission-form
-- name: Office of Intelligence & Analysis
+- address:
+    address_lines:
+    - 'FOIA: Office of Intelligence & Analysis'
+    - U.S. Department of Homeland Security
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20528'
+  name: Office of Intelligence & Analysis
   request_form: http://www.dhs.gov/dhs-foia-request-submission-form
-- name: Directorate for National Protection and Programs
+- address:
+    address_lines:
+    - 'FOIA: Directorate for National Protection and Programs'
+    - U.S. Department of Homeland Security
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20528'
+  name: Directorate for National Protection and Programs
   request_form: http://www.dhs.gov/dhs-foia-request-submission-form
-- name: Office of Operations Coordination and Planning
+- address:
+    address_lines:
+    - 'FOIA: Office of Operations Coordination and Planning'
+    - U.S. Department of Homeland Security
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20528'
+  name: Office of Operations Coordination and Planning
   request_form: http://www.dhs.gov/dhs-foia-request-submission-form
 - name: Science & Technology Directorate
   request_form: http://www.dhs.gov/dhs-foia-request-submission-form

--- a/contacts/manual_data/DOI.yaml
+++ b/contacts/manual_data/DOI.yaml
@@ -20,3 +20,8 @@ departments:
 - name: Office of Natural Resources Revenue
   emails:
   - os_foia@ios.doi.gov
+- name: Office of the Special Trustee
+  public_liaison:
+    name: Veronica Herkshan
+    phone:
+      - 505-816-1645

--- a/contacts/manual_data/HHS.yaml
+++ b/contacts/manual_data/HHS.yaml
@@ -1,5 +1,13 @@
 departments:
-- description: ACL brings together the efforts and achievements of the Administration
+- address:
+    address_lines:
+    - FOIA Requester Service Center
+    - Administration for Community Living
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20201'
+  description: ACL brings together the efforts and achievements of the Administration
     on Aging, the Administration on Intellectual and Developmental Disabilities, and
     the HHS Office on Disability to serve as the Federal agency responsible for increasing
     access to community supports, while focusing attention and resources on the unique

--- a/contacts/manual_data/NASA.yaml
+++ b/contacts/manual_data/NASA.yaml
@@ -28,8 +28,15 @@ departments:
   request_form: http://socialforms.nasa.gov/foia
 - name: Langley Research Center
   request_form: http://socialforms.nasa.gov/foia
-- name: Stennis Space Center
+  address:
+    address_lines:
+    - 'FOIA: Sally Blibo'
+    city: Stennis Space Center
+    state: MS
+    street: 'Building 1100 room 304D'
+    zip: '39529'
   emails:
   - ssc-foia@nasa.gov
+  name: Stennis Space Center
   request_form: http://socialforms.nasa.gov/foia
 name: National Aeronautics and Space Administration

--- a/contacts/manual_data/ODNI.yaml
+++ b/contacts/manual_data/ODNI.yaml
@@ -1,0 +1,11 @@
+departments:
+- address:
+    address_lines:
+    - Jennifer L. Hudson
+    - Director, Information Management Division
+    - Office of the Director of National Intelligence
+    city: Washington
+    state: DC
+    street: ''
+    zip: '20511'
+  name: Office of the Director of National Intelligence

--- a/contacts/manual_data/U.S. DOL.yaml
+++ b/contacts/manual_data/U.S. DOL.yaml
@@ -33,6 +33,16 @@ departments:
 - name: Office of Federal Contract Compliance Programs
   emails:
   - foiarequests@dol.gov
+- address:
+    address_lines:
+    - 'FOIA: Wage and Hour Division'
+    - U. S. Department of Labor
+    - Room S-3201
+    city: Washington
+    state: DC
+    street: 200 Constitution Avenue, N.W.
+    zip: '20210'
+  name: Wage and Hour Division
 - name: Women's Bureau
   emails:
   - foiarequests@dol.gov

--- a/contacts/manual_data/USDA.yaml
+++ b/contacts/manual_data/USDA.yaml
@@ -7,6 +7,10 @@ departments:
 - name: Research, Education & Economics
   website: http://www.ars.usda.gov/is/foia/foiaform.htm
 - name: National Finance Center
+  public_liaison:
+    name: Shri Alsobrook, Sandy Francois
+    phone:
+      - 504-426-0327
   request_form: https://efoia-pal.usda.gov/palMain.aspx
   website: https://www.nfc.usda.gov/FOIA/FOIA_home.html
 - name: Agricultural Marketing Service


### PR DESCRIPTION
This PR adds the 8 missing addresses. Some of them are not traditional because they don't have a street. For example, Directorate for National Protection and Programs.

``` yaml
- address:
    address_lines:
    - 'FOIA: Directorate for National Protection and Programs'
    - U.S. Department of Homeland Security
    city: Washington
    state: DC
    street: ''
    zip: '20528'
```

Using our current template this will cause a gap between the address_lines and city/state/zip fields on foia_hub so I've also submitted a template change PR.
