### PR TITLE
Cleaning Keywords

### DIFF
--- a/contacts/clean_keywords.py
+++ b/contacts/clean_keywords.py
@@ -10,6 +10,9 @@ from stop_words import get_stop_words
 
 STOP_WORDS = get_stop_words('english')
 
+# Threshold set to 25 percentile of scores
+THRESHOLD = np.float64(0.940983)
+
 
 def flatten_keywords(keywords):
     """
@@ -98,10 +101,12 @@ def get_tf_idf(keyword, keywords, agency, agencies, total_agencies):
 def clean_keywords(keywords, scores):
     """ Removes any keywords that have less than the median tfidf score """
 
-    if len(scores) > 1:
-        median = np.median(scores)
+    threshold = THRESHOLD
+    if len(scores) > 0:
+        if not threshold:
+            threshold = np.median(scores)
         keywords = np.array(keywords)
-        keywords = keywords[scores > median].tolist()
+        keywords = keywords[scores > threshold].tolist()
 
     return keywords
 
@@ -163,7 +168,5 @@ def updated_yamls(glob_path):
                 total_agencies=total_agencies)
         write_yaml(filename=filename, data=agency)
 
-
 if __name__ == "__main__":
-
     updated_yamls("data" + os.sep + "*.yaml")

--- a/contacts/clean_keywords.py
+++ b/contacts/clean_keywords.py
@@ -13,10 +13,16 @@ STOP_WORDS = get_stop_words('english')
 # Threshold set to 25 percentile of scores
 THRESHOLD = np.float64(0.940983)
 
+"""
+This script uses the Term Frequency–Inverse Document Frequency statistic
+(tf-idf) to eliminate the keywords that score in the bottom 25th percentile
+for relevance.
+"""
+
 
 def flatten_keywords(keywords):
     """
-    Converts phases into keywords while removing stop words and parentheses
+    Convert phrases into keywords while removing stop words and parentheses
     """
 
     flattened_keywords = []
@@ -32,7 +38,7 @@ def flatten_keywords(keywords):
 
 def update_keyword_agency_dict(keywords_agency, keywords, agency_name):
     """
-    Generates/updates a dictionary, which maps keywords to agencies
+    Generate/update a dictionary, which maps keywords to agencies
     """
     for keyword in keywords:
         if keyword in keywords_agency:
@@ -43,7 +49,7 @@ def update_keyword_agency_dict(keywords_agency, keywords, agency_name):
 
 def extract_agency_keywords(agency, agency_keywords, keywords_agency):
     """
-    Updates the agency_keywords and keywords_agency dictionaries with data
+    Update the agency_keywords and keywords_agency dictionaries with data
     from a specific agency
     """
 
@@ -67,7 +73,7 @@ def extract_agency_keywords(agency, agency_keywords, keywords_agency):
 
 def get_keyword_dicts(glob_path):
     """
-    Collects a dictionary that maps keywords to agencies and a dictionary that
+    Collect a dictionary that maps keywords to agencies and a dictionary that
     maps agencies to keywords
     """
 
@@ -86,10 +92,10 @@ def get_keyword_dicts(glob_path):
 
 def get_tf_idf(keyword, keywords, agency, agencies, total_agencies):
     """
-    Computes tf_idf score of a given keyword currently tf (term freqency) has
+    Compute tf_idf score of a given keyword currently tf (term frequency) has
     no weighting and idf is a simple inverse frequency.
 
-    for more info http://en.wikipedia.org/wiki/Tf%E2%80%93idf
+    For more info http://en.wikipedia.org/wiki/Tf%E2%80%93idf
     """
 
     idf = math.log(total_agencies / len(keywords.get(keyword)))
@@ -107,7 +113,7 @@ def clean_keywords(keywords, scores):
             threshold = np.median(scores)
         keywords = np.array(keywords)
         keywords = keywords[scores > threshold].tolist()
-
+    keywords.sort()
     return keywords
 
 
@@ -141,7 +147,8 @@ def apply_tf_idf(agency, agencies, keywords, total_agencies):
                     agencies=agencies,
                     total_agencies=total_agencies)
                 tf_idf_scores.append(tf_idf)
-            office['keywords'] = clean_keywords(keyword_set, tf_idf_scores)
+            office['keywords'] = clean_keywords(
+                keyword_set, tf_idf_scores)
     return agency
 
 

--- a/contacts/clean_keywords.py
+++ b/contacts/clean_keywords.py
@@ -10,7 +10,7 @@ from stop_words import get_stop_words
 
 STOP_WORDS = get_stop_words('english')
 
-# Threshold set to 25 percentile of scores
+# Threshold set to 30ish percentile of scores
 THRESHOLD = np.float64(0.940983)
 
 """
@@ -93,13 +93,13 @@ def get_keyword_dicts(glob_path):
 def get_tf_idf(keyword, keywords, agency, agencies, total_agencies):
     """
     Compute tf_idf score of a given keyword currently tf (term frequency) has
-    no weighting and idf is a simple inverse frequency.
+    log weighting and idf is a simple inverse frequency.
 
     For more info http://en.wikipedia.org/wiki/Tf%E2%80%93idf
     """
 
     idf = math.log(total_agencies / len(keywords.get(keyword)))
-    tf = agencies.get(agency).count(keyword)
+    tf = math.log(1 + agencies.get(agency).count(keyword))
     tf_idf = tf * idf
     return tf_idf
 
@@ -174,6 +174,7 @@ def updated_yamls(glob_path):
                 keywords=keywords,
                 total_agencies=total_agencies)
         write_yaml(filename=filename, data=agency)
+
 
 if __name__ == "__main__":
     updated_yamls("data" + os.sep + "*.yaml")

--- a/contacts/clean_keywords.py
+++ b/contacts/clean_keywords.py
@@ -1,0 +1,135 @@
+# from copy import deepcopy
+from glob import iglob
+
+import math
+import os
+import yaml
+
+import numpy as np
+from stop_words import get_stop_words
+
+stop_words = get_stop_words('english')
+
+
+def flatten_keywords(keywords):
+    """
+    Converts phases into keywords while removing stop words and parentheses
+    """
+
+    flattened_keywords = []
+    if keywords:
+        for keyword in keywords:
+            split_words = list(set(keyword.lower().split(' ')))
+            for word in split_words:
+                word = word.strip("()")
+                if word not in stop_words:
+                    flattened_keywords.append(word)
+    return flattened_keywords
+
+
+def update_keyword_agency_dict(keywords_agency, keywords, agency_name):
+    """
+    Generates/updates a dictionary, which maps keywords to agencies
+    """
+    for keyword in keywords:
+        if keyword in keywords_agency:
+            keywords_agency[keyword].append(agency_name)
+        else:
+            keywords_agency[keyword] = [agency_name]
+
+
+def get_keyword_dicts(glob_path):
+
+    agency_keywords = {}
+    keywords_agency = {}
+
+    for filename in iglob(glob_path):
+        with open(filename) as f:
+            agency = yaml.load(f.read())
+
+        keywords = flatten_keywords(agency.get('keywords'))
+        if keywords:
+            update_keyword_agency_dict(
+                keywords_agency=keywords_agency,
+                keywords=keywords,
+                agency_name=agency.get('name'))
+            agency_keywords[agency.get('name')] = keywords
+
+        for office in agency['departments']:
+            keywords = flatten_keywords(office.get('keywords'))
+            if keywords:
+                update_keyword_agency_dict(
+                    keywords_agency=keywords_agency,
+                    keywords=keywords,
+                    agency_name=office.get('name'))
+                agency_keywords[office.get('name')] = keywords
+    return agency_keywords, keywords_agency
+
+
+def get_tf_idf(keyword, keywords, agency, agencies, total_agencies):
+    """
+    Computes tf_idf score of a given keyword currently tf (term freqency) has
+    no weighting and idf is a simple inverse frequency.
+
+    for more info http://en.wikipedia.org/wiki/Tf%E2%80%93idf
+    """
+
+    idf = math.log(total_agencies / len(keywords.get(keyword)))
+    tf = agencies.get(agency).count(keyword)
+    tf_idf = tf * idf
+    return tf_idf
+
+
+def clean_keywords(keywords, scores):
+
+    if len(scores) > 1:
+        median = np.median(scores)
+        keywords = np.array(keywords)
+        keywords = keywords[scores > median].tolist()
+
+    return keywords
+
+
+def apply_tf_idf(glob_path):
+
+    agencies, keywords = get_keyword_dicts(glob_path)
+    total_agencies = len(agencies.keys())
+
+    for filename in iglob(glob_path):
+        with open(filename) as f:
+            agency = yaml.load(f.read())
+
+        if 'keywords' in agency:
+            tf_idf_scores = []
+            keyword_set = list(set(agencies.get(agency['name'])))
+            for keyword in keyword_set:
+                tf_idf = get_tf_idf(
+                    keyword=keyword,
+                    keywords=keywords,
+                    agency=agency['name'],
+                    agencies=agencies,
+                    total_agencies=total_agencies)
+                tf_idf_scores.append(tf_idf)
+            agency['keywords'] = clean_keywords(keyword_set, tf_idf_scores)
+
+        for office in agency['departments']:
+            if 'keywords' in office:
+                keyword_set = list(set(agencies.get(office['name'])))
+                tf_idf_scores = []
+                for keyword in keyword_set:
+                    tf_idf = get_tf_idf(
+                        keyword=keyword,
+                        keywords=keywords,
+                        agency=office['name'],
+                        agencies=agencies,
+                        total_agencies=total_agencies)
+                office['keywords'] = clean_keywords(keyword_set, tf_idf_scores)
+
+        with open(filename, 'w') as new_file:
+            new_file.write(yaml.dump(
+                agency, default_flow_style=False, allow_unicode=True))
+
+
+if __name__ == "__main__":
+
+    apply_tf_idf("data" + os.sep + "*.yaml")

--- a/contacts/clean_keywords.py
+++ b/contacts/clean_keywords.py
@@ -106,7 +106,7 @@ def clean_keywords(keywords, scores):
     return keywords
 
 
-def apply_tf_idf(agencies, keywords, agency, total_agencies):
+def apply_tf_idf(agency, agencies, keywords, total_agencies):
     """
     Applies tfidf to score keywords and returns updated keywords
     """
@@ -135,6 +135,7 @@ def apply_tf_idf(agencies, keywords, agency, total_agencies):
                     agency=office['name'],
                     agencies=agencies,
                     total_agencies=total_agencies)
+                tf_idf_scores.append(tf_idf)
             office['keywords'] = clean_keywords(keyword_set, tf_idf_scores)
     return agency
 
@@ -156,9 +157,9 @@ def updated_yamls(glob_path):
     for filename in iglob(glob_path):
         with open(filename) as f:
             agency = apply_tf_idf(
+                agency=yaml.load(f.read()),
                 agencies=agencies,
                 keywords=keywords,
-                agency=yaml.load(f.read()),
                 total_agencies=total_agencies)
         write_yaml(filename=filename, data=agency)
 

--- a/contacts/data/ABMC.yaml
+++ b/contacts/data/ABMC.yaml
@@ -73,8 +73,8 @@ description: The American Battle Monuments Commission manages 24 overseas milita
   cemeteries, and 25 memorials, monuments, and markers. Nearly all the cemeteries
   and memorials honor those who served in World War I or World War II.
 keywords:
-- Freedom of information
-- Monuments and memorials
+- memorials
+- monuments
 name: American Battle Monuments Commission
 request_time_stats:
   '2010':

--- a/contacts/data/ACUS.yaml
+++ b/contacts/data/ACUS.yaml
@@ -80,10 +80,7 @@ departments:
 description: 'The Administrative Conference of the United States is an independent
   federal agency dedicated to improving federal agency administrative processes and
   procedures. '
-keywords:
-- Administrative practice and procedure
-- Freedom of information
-- Privacy
+keywords: []
 name: Administrative Conference of the United States
 request_time_stats:
   '2010':

--- a/contacts/data/AFRH.yaml
+++ b/contacts/data/AFRH.yaml
@@ -61,9 +61,9 @@ departments:
 description: The Gulfport and Washington campuses of the Armed Forces Retirement Home
   are retirement centers for veterans of the U.S. military.
 keywords:
-- Armed forces
-- Environmental protection
-- Retirement
+- armed
+- forces
+- retirement
 name: Armed Forces Retirement Home
 request_time_stats:
   '2011':

--- a/contacts/data/BBG.yaml
+++ b/contacts/data/BBG.yaml
@@ -76,15 +76,13 @@ departments:
 description: The Broadcasting Board of Governors broadcasts news and information about
   the United States and the world to audiences abroad.
 keywords:
-- Administrative practice and procedure
-- Foreign relations
-- Freedom of information
-- News media
-- Privacy
-- Radio
-- Recordings
-- Sunshine Act
-- Television
+- act
+- media
+- news
+- radio
+- recordings
+- sunshine
+- television
 name: Broadcasting Board of Governors
 request_time_stats:
   '2010':

--- a/contacts/data/CEQ.yaml
+++ b/contacts/data/CEQ.yaml
@@ -96,12 +96,7 @@ description: The Counicl on Environmental Quality coordinates federal environmen
   activities, and assists in the development of environmental policy across the executive
   branch.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Conflict of interests
-- Courts
-- Freedom of information
-- Government employees
+- courts
 name: Council on Environmental Quality
 request_time_stats:
   '2008':

--- a/contacts/data/CFPB.yaml
+++ b/contacts/data/CFPB.yaml
@@ -48,63 +48,51 @@ description: The Consumer Financial Protection Bureau ensures that financial pro
   the Bureau also works to make credit card, mortgage, and other loan disclosures
   clearer so consumers can understand their rights and responsibilities.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Advertising
-- Aged
-- Agriculture
-- Bank deposit insurance
-- Blind
-- Civil rights
-- Communications
-- Condominiums
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Credit
-- Credit unions
-- Crime
-- Currency
-- Electronic funds transfers
-- Employment
-- Equal access to justice
-- Equal employment opportunity
-- Exports
-- Federal Reserve System
-- Federal buildings and facilities
-- Foreign banking
-- Freedom of information
-- Government employees
-- Grant programs-housing and community development
-- HMDA
-- Holding companies
-- Housing
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- Investigations
-- Investments
-- Law enforcement
-- Loan programs-housing and community development
-- Marital status discrimination
-- Mortgages
-- National banks
-- Penalties
-- Privacy
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Rural areas
-- Savings associations
-- Securities
-- Sex discrimination
-- State and local governments
-- Surety bonds
-- Trade practices
-- Truth in lending
-- Truth in savings
-- Wages
-- credit cards
+- access
+- advertising
+- associations
+- bank
+- banking
+- banks
+- blind
+- cards
+- companies
+- condominiums
+- confidential
+- consumer
+- credit
+- crime
+- currency
+- deposit
+- discrimination
+- electronic
+- exports
+- federal
+- funds
+- governments
+- hmda
+- holding
+- investments
+- justice
+- lending
+- local
+- marital
 - mortgage
+- mortgages
+- practices
+- programs-housing
+- religious
+- reserve
+- rural
+- savings
+- sex
+- state
+- status
+- surety
+- system
+- transfers
+- truth
+- unions
 name: Consumer Financial Protection Bureau
 request_time_stats:
   '2013':

--- a/contacts/data/CFTC.yaml
+++ b/contacts/data/CFTC.yaml
@@ -105,54 +105,48 @@ description: The mission of the CFTC is to protect market users and the public f
   and other actions. The CFTC also engages in public education and outreach by participating
   in consumer groups and issuing Consumer Advisories and other educational materials.
 keywords:
-- Administrative practice and procedure
-- Advertising
-- Agricultural commodities
-- Agriculture
-- Antitrust
-- Authority delegations (Government agencies)
-- Bankruptcy
-- Brokers
-- Business and industry
-- Claims
-- Commodity Futures Trading Commission
-- Commodity futures
-- Conduct standards
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Cooperatives
-- Cotton
-- Credit
-- Credit unions
-- Currency
-- Ethics
-- Foreign banking
-- Foreign currencies
-- Fraud
-- Freedom of information
-- Gambling
-- Government securities
-- Grains
-- Holding companies
-- Insurance
-- Insurance companies
-- Investigations
-- Investment companies
-- Investments
-- Law enforcement
-- National banks
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Reporting and recordkeeping requirements
-- Savings associations
-- Securities
-- Security measures
-- Sunshine Act
-- Trade practices
-- Trusts and trustees
-- Whistleblowing
+- act
+- advertising
+- agricultural
+- antitrust
+- associations
+- authority
+- banking
+- bankruptcy
+- banks
+- brokers
+- commission
+- commodities
+- commodity
+- companies
+- conduct
+- confidential
+- consumer
+- cooperatives
+- cotton
+- credit
+- currencies
+- currency
+- delegations
+- ethics
+- fraud
+- futures
+- gambling
+- grains
+- holding
+- investment
+- investments
+- measures
+- practices
+- savings
+- securities
+- standards
+- sunshine
+- trading
+- trustees
+- trusts
+- unions
+- whistleblowing
 name: Commodity Futures Trading Commission
 request_time_stats:
   '2008':

--- a/contacts/data/CIA.yaml
+++ b/contacts/data/CIA.yaml
@@ -97,8 +97,7 @@ departments:
 description: The Central Intelligence Agency (CIA) is an independent US Government
   agency responsible for providing national security intelligence to senior US policymakers.
 keywords:
-- Classified information
-- Freedom of information
+- classified
 - counterintelligence
 - espionage
 - spies

--- a/contacts/data/CNCS.yaml
+++ b/contacts/data/CNCS.yaml
@@ -98,116 +98,94 @@ departments:
 description: The Corporation for National and Community Service encourages and provides
   community service opportunities, including AmeriCorps and Senior Corps.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Airports
-- American Samoa
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Civil rights
-- Claims
-- Colleges and universities
-- Communications
-- Community development
-- Copyright
-- Credit
-- Cultural exchange programs
-- Drug abuse
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Equal employment opportunity
-- Federal buildings and facilities
-- Federally affected areas
-- Fraud
-- Government contracts
-- Government employees
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Mass transportation
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Pacific Islands Trust Territory
-- Penalties
-- Privacy
-- Private schools
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Securities
-- Sex discrimination
-- Small businesses
-- State and local governments
-- Student aid
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Volunteers
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- adult
+- affected
+- aid
+- airports
+- american
+- blind
+- broadband
+- businesses
+- colleges
+- construction
+- copyright
+- cultural
+- disadvantaged
+- disposal
+- elementary
+- exchange
+- federally
+- fellowships
+- fraud
+- governments
+- guam
+- highways
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- improvement
+- indians-education
+- international
+- inventions
+- iraq
+- kuwait
+- lebanon
+- local
+- manpower
+- mariana
+- mass
+- migrant
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- pacific
+- patents
+- private
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-social
+- railroads
+- rates
+- rehabilitation
+- religious
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- secondary
+- sex
+- small
+- state
+- student
+- study
+- subjects
+- supply
+- teachers
+- technical
+- telecommunications
+- telephone
+- territory
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- volunteers
+- waste
+- watersheds
+- women
 name: Corporation for National and Community Service
 request_time_stats:
   '2008':

--- a/contacts/data/CPPBSD.yaml
+++ b/contacts/data/CPPBSD.yaml
@@ -111,16 +111,7 @@ description: The AbilityOne Commission creates job opportunities for people who 
   blind or have other significant disabilities in the manufacture and delivery of
   products and services to the Federal Government.
 keywords:
-- Administrative practice and procedure
-- Civil rights
-- Equal employment opportunity
-- Federal buildings and facilities
-- Freedom of information
-- Government procurement
-- Individuals with disabilities
-- Organization and functions (Government agencies)
-- Privacy
-- Reporting and recordkeeping requirements
+- procurement
 name: Committee for Purchase from People Who Are Blind or Severely Disabled
 request_time_stats:
   '2008':

--- a/contacts/data/CSB.yaml
+++ b/contacts/data/CSB.yaml
@@ -107,16 +107,9 @@ departments:
 description: The Chemical Safety and Hazard Investigation Board investigates industrial
   chemical accidents.
 keywords:
-- Administrative practice and procedure
-- Archives and records
-- Claims
-- Freedom of information
-- Government employees
-- Investigations
-- Organization and functions (Government agencies)
-- Privacy
-- Reporting and recordkeeping requirements
-- Sunshine Act
+- act
+- archives
+- sunshine
 name: Chemical Safety and Hazard Investigation Board
 request_time_stats:
   '2008':

--- a/contacts/data/DHS.yaml
+++ b/contacts/data/DHS.yaml
@@ -60,19 +60,13 @@ departments:
     phone:
     - 800-375-5283
   keywords:
-  - Administrative practice and procedure
-  - Aliens
-  - Authority delegations (Government agencies)
-  - Employment
-  - Foreign officials
-  - Freedom of information
-  - Health professions
-  - Immigration
-  - Penalties
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Students
-  - Surety bonds
+  - aliens
+  - authority
+  - delegations
+  - immigration
+  - officials
+  - students
+  - surety
   name: U.S. Citizenship & Immigration Services
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -282,117 +276,113 @@ departments:
     phone:
     - 202-475-3522
   keywords:
-  - Administrative practice and procedure
-  - Advertising
-  - Air carriers
-  - Aircraft
-  - Airports
-  - Alaska
-  - Alcohol abuse
-  - Alcohol and alcoholic beverages
-  - Anchorage grounds
-  - Archives and records
-  - Armed forces
-  - Armed forces reserves
-  - Authority delegations (Government agencies)
-  - Aviation safety
-  - Benzene
-  - Bridges
-  - Business and industry
-  - Cargo vessels
-  - Citizenship and naturalization
-  - Civil rights
-  - Claims
-  - Coast Guard
-  - Code of Federal Regulations
-  - Colleges and universities
-  - Communications equipment
-  - Conflict of interests
-  - Continental shelf
-  - Defense Department
-  - Diving
-  - Drug abuse
-  - Drug testing
-  - Drugs
-  - Education
-  - Employment
-  - Endangered and threatened species
-  - Environmental protection
-  - Explosives
-  - Fire prevention
-  - Fishing vessels
-  - Foreign relations
-  - Freedom of information
-  - Freight
-  - Gases
-  - Government employees
-  - Government publications
-  - Grant programs-education
-  - Grant programs-veterans
-  - Great Lakes
-  - Harbors
-  - Hazardous materials transportation
-  - Hazardous substances
-  - Health care
-  - Insurance
-  - Intergovernmental relations
-  - Investigations
-  - Labeling
-  - Laboratories
-  - Law enforcement
-  - Law enforcement officers
-  - Loan programs-education
-  - Loan programs-veterans
-  - Manpower training programs
-  - Marine mammals
-  - Marine resources
-  - Marine safety
-  - Maritime carriers
-  - Maritime security
-  - Measurement standards
-  - Military personnel
-  - Mortgages
-  - Motor carriers
-  - National Transportation Safety Board
-  - Natural gas
-  - Navigation (water)
-  - Nuclear vessels
-  - Occupational safety and health
-  - Oceanographic research vessels
-  - Oil and gas exploration
-  - Oil pollution
-  - Organization and functions (Government agencies)
-  - Packaging and containers
-  - Passenger vessels
-  - Penalties
-  - Petroleum
-  - Radiation protection
-  - Radio
-  - Reporting and recordkeeping requirements
-  - Research
-  - Safety
-  - Schools
-  - Seamen
-  - Security measures
-  - Sewage disposal
-  - Signs and symbols
-  - Surety bonds
-  - Telecommunications
-  - Telephone
-  - Terrorism
-  - Transportation
-  - Travel
-  - Travel and transportation expenses
-  - Treaties
-  - Vessels
-  - Veterans
-  - Vocational education
-  - Vocational rehabilitation
-  - Volunteers
-  - Wages
-  - Water pollution control
-  - Waterways
-  - Whistleblowing
+  - abuse
+  - advertising
+  - aircraft
+  - airports
+  - alaska
+  - alcohol
+  - alcoholic
+  - anchorage
+  - archives
+  - armed
+  - authority
+  - aviation
+  - benzene
+  - beverages
+  - board
+  - bridges
+  - care
+  - cargo
+  - carriers
+  - citizenship
+  - coast
+  - code
+  - colleges
+  - containers
+  - continental
+  - defense
+  - delegations
+  - department
+  - disposal
+  - diving
+  - drug
+  - drugs
+  - endangered
+  - equipment
+  - expenses
+  - exploration
+  - explosives
+  - fire
+  - fishing
+  - forces
+  - freight
+  - gas
+  - gases
+  - great
+  - grounds
+  - guard
+  - harbors
+  - hazardous
+  - labeling
+  - laboratories
+  - lakes
+  - mammals
+  - manpower
+  - marine
+  - maritime
+  - materials
+  - measurement
+  - measures
+  - military
+  - mortgages
+  - natural
+  - naturalization
+  - navigation
+  - nuclear
+  - occupational
+  - oceanographic
+  - officers
+  - oil
+  - packaging
+  - passenger
+  - personnel
+  - petroleum
+  - pollution
+  - prevention
+  - programs-education
+  - programs-veterans
+  - publications
+  - radiation
+  - radio
+  - regulations
+  - rehabilitation
+  - reserves
+  - seamen
+  - security
+  - sewage
+  - shelf
+  - signs
+  - species
+  - standards
+  - substances
+  - surety
+  - symbols
+  - telecommunications
+  - telephone
+  - terrorism
+  - testing
+  - threatened
+  - training
+  - travel
+  - treaties
+  - universities
+  - vessels
+  - veterans
+  - vocational
+  - volunteers
+  - waterways
+  - whistleblowing
   name: U.S. Coast Guard
   phone: 202-475-3522
   public_liaison:
@@ -494,101 +484,108 @@ departments:
     phone:
     - 202-325-0150
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Air carriers
-  - Air pollution control
-  - Air transportation
-  - Aircraft
-  - Airmen
-  - Airports
-  - Alcohol and alcoholic beverages
-  - Aliens
-  - American Samoa
-  - Antidumping
-  - Authority delegations (Government agencies)
-  - Bonds
-  - Brokers
-  - Canada
-  - Cargo vessels
-  - Caribbean Basin initiative
-  - Cigars and cigarettes
-  - Claims
-  - Coastal zone
-  - Coffee
-  - Common carriers
-  - Computer technology
-  - Confidential business information
-  - Cotton
-  - Countervailing duties
-  - Courts
-  - Cuba
-  - Cultural exchange programs
-  - Customs duties and inspection
-  - Drug traffic control
-  - Electronic products
-  - Employment
-  - Executive orders
-  - Exports
-  - Fishing vessels
-  - Foreign currencies
-  - Foreign officials
-  - Foreign trade zones
-  - Freedom of information
-  - Freight
-  - Fruit juices
-  - Government contracts
-  - Government employees
-  - Government procurement
-  - Guam
-  - Harbors
-  - Health professions
-  - Immigration
-  - Imports
-  - International organizations
-  - Kingman Reef
-  - Labeling
-  - Laboratories
-  - Law enforcement
-  - Liquors
-  - Lotteries
-  - Maritime carriers
-  - Metals
-  - Mexico
-  - Midway Islands
-  - Motor carriers
-  - Motor vehicles
-  - Oil imports
-  - Oil pollution
-  - Organization and functions (Government agencies)
-  - Packaging and containers
-  - Passenger vessels
-  - Passports and visas
-  - Penalties
-  - Petroleum
-  - Privacy
-  - Puerto Rico
-  - Railroads
-  - Reporting and recordkeeping requirements
-  - Seals and insignia
-  - Seamen
-  - Search warrants
-  - Security measures
-  - Seizures and forfeitures
-  - Students
-  - Sugar
-  - Surety bonds
-  - Taxes
-  - Trade agreements
-  - Trademarks
-  - Travel restrictions
-  - Vessels
-  - Wages
-  - Wake Island
-  - Warehouses
-  - Wheat
-  - Wine
-  - Wool
+  - agreements
+  - air
+  - aircraft
+  - airmen
+  - airports
+  - alcohol
+  - alcoholic
+  - aliens
+  - american
+  - antidumping
+  - authority
+  - basin
+  - beverages
+  - bonds
+  - brokers
+  - canada
+  - cargo
+  - caribbean
+  - carriers
+  - cigarettes
+  - cigars
+  - coastal
+  - coffee
+  - common
+  - computer
+  - confidential
+  - containers
+  - cotton
+  - countervailing
+  - courts
+  - cuba
+  - cultural
+  - currencies
+  - customs
+  - delegations
+  - duties
+  - electronic
+  - exchange
+  - executive
+  - exports
+  - fishing
+  - forfeitures
+  - freight
+  - fruit
+  - guam
+  - harbors
+  - immigration
+  - imports
+  - initiative
+  - insignia
+  - inspection
+  - international
+  - island
+  - juices
+  - kingman
+  - labeling
+  - laboratories
+  - liquors
+  - lotteries
+  - maritime
+  - measures
+  - metals
+  - mexico
+  - midway
+  - motor
+  - officials
+  - oil
+  - orders
+  - packaging
+  - passenger
+  - passports
+  - petroleum
+  - pollution
+  - procurement
+  - puerto
+  - railroads
+  - reef
+  - restrictions
+  - rico
+  - samoa
+  - seals
+  - seamen
+  - search
+  - seizures
+  - students
+  - sugar
+  - surety
+  - trade
+  - trademarks
+  - traffic
+  - travel
+  - vehicles
+  - vessels
+  - visas
+  - wake
+  - warehouses
+  - warrants
+  - wheat
+  - wine
+  - wool
+  - zone
+  - zones
   name: U.S. Customs & Border Protection
   phone: 202-325-0150
   public_liaison:
@@ -698,131 +695,117 @@ departments:
     phone:
     - 202-646-3323
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Adult education
-  - Advisory committees
-  - Aged
-  - Agriculture
-  - Airports
-  - Aliens
-  - American Samoa
-  - Blind
-  - Broadband
-  - Buildings and facilities
-  - Business and industry
-  - Civil rights
-  - Claims
-  - Classified information
-  - Coastal zone
-  - Colleges and universities
-  - Communications
-  - Community development
-  - Copyright
-  - Courts
-  - Credit
-  - Cultural exchange programs
-  - Disaster assistance
-  - Drug abuse
-  - Education
-  - Education of disadvantaged
-  - Education of individuals with disabilities
-  - Educational facilities
-  - Educational research
-  - Educational study programs
-  - Electric power
-  - Electric power rates
-  - Electric utilities
-  - Elementary and secondary education
-  - Employment
-  - Environmental impact statements
-  - Equal educational opportunity
-  - Equal employment opportunity
-  - Federal buildings and facilities
-  - Federally affected areas
-  - Fire prevention
-  - Flood insurance
-  - Flood plains
-  - Freedom of information
-  - Government contracts
-  - Government employees
-  - Government property management
-  - Grant programs
-  - Grant programs-education
-  - Grant programs-health
-  - Grant programs-housing and community development
-  - Grant programs-social programs
-  - Guam
-  - Highways and roads
-  - Home improvement
-  - Homeless
-  - Hospitals
-  - Hostages
-  - Housing
-  - Human research subjects
-  - Indians
-  - Indians-education
-  - Indians-lands
-  - Indians-tribal government
-  - Individuals with disabilities
-  - Insurance
-  - Intergovernmental relations
-  - International organizations
-  - Inventions and patents
-  - Investigations
-  - Iraq
-  - Kuwait
-  - Lebanon
-  - Loan programs
-  - Loan programs-agriculture
-  - Loan programs-communications
-  - Loan programs-energy
-  - Loan programs-housing and community development
-  - Manpower training programs
-  - Mass transportation
-  - Migrant labor
-  - Mortgage insurance
-  - Mortgages
-  - Natural resources
-  - Nonprofit organizations
-  - Northern Mariana Islands
-  - Nuclear power plants and reactors
-  - Organization and functions (Government agencies)
-  - Pacific Islands Trust Territory
-  - Penalties
-  - Privacy
-  - Private schools
-  - Public lands
-  - Radiation protection
-  - Railroads
-  - Religious discrimination
-  - Reporting and recordkeeping requirements
-  - Rural areas
-  - Scholarships and fellowships
-  - School construction
-  - Schools
-  - Science and technology
-  - Securities
-  - Sex discrimination
-  - Small businesses
-  - State and local governments
-  - Student aid
-  - Teachers
-  - Technical assistance
-  - Telecommunications
-  - Telephone
-  - Terrorism
-  - Urban areas
-  - Veterans
-  - Virgin Islands
-  - Vocational education
-  - Vocational rehabilitation
-  - Waste treatment and disposal
-  - Water pollution control
-  - Water resources
-  - Water supply
-  - Watersheds
-  - Women
+  - adult
+  - advisory
+  - affected
+  - aid
+  - airports
+  - aliens
+  - american
+  - blind
+  - broadband
+  - businesses
+  - classified
+  - coastal
+  - colleges
+  - committees
+  - construction
+  - copyright
+  - courts
+  - cultural
+  - disadvantaged
+  - disaster
+  - disposal
+  - elementary
+  - exchange
+  - federally
+  - fellowships
+  - fire
+  - flood
+  - governments
+  - guam
+  - highways
+  - home
+  - homeless
+  - hospitals
+  - hostages
+  - human
+  - impact
+  - improvement
+  - indians-education
+  - indians-lands
+  - indians-tribal
+  - international
+  - inventions
+  - iraq
+  - kuwait
+  - lands
+  - lebanon
+  - local
+  - manpower
+  - mariana
+  - mass
+  - migrant
+  - mortgage
+  - mortgages
+  - natural
+  - nonprofit
+  - northern
+  - nuclear
+  - pacific
+  - patents
+  - plains
+  - plants
+  - power
+  - prevention
+  - private
+  - programs-agriculture
+  - programs-communications
+  - programs-education
+  - programs-energy
+  - programs-housing
+  - programs-social
+  - radiation
+  - railroads
+  - rates
+  - reactors
+  - rehabilitation
+  - religious
+  - roads
+  - rural
+  - samoa
+  - scholarships
+  - school
+  - schools
+  - science
+  - secondary
+  - sex
+  - small
+  - state
+  - statements
+  - student
+  - study
+  - subjects
+  - supply
+  - teachers
+  - technical
+  - telecommunications
+  - telephone
+  - territory
+  - terrorism
+  - training
+  - treatment
+  - trust
+  - universities
+  - urban
+  - utilities
+  - veterans
+  - virgin
+  - vocational
+  - waste
+  - watersheds
+  - women
+  - zone
   name: Federal Emergency Management Agency
   phone: 202-646-3323
   public_liaison:
@@ -1013,21 +996,14 @@ departments:
     phone:
     - 202-732-4265
   keywords:
-  - Administrative practice and procedure
-  - Aliens
-  - Authority delegations (Government agencies)
-  - Employment
-  - Foreign officials
-  - Foreign relations
-  - Freedom of information
-  - Health professions
-  - Immigration
-  - Penalties
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Students
-  - Surety bonds
-  - Treaties
+  - aliens
+  - authority
+  - delegations
+  - immigration
+  - officials
+  - students
+  - surety
+  - treaties
   name: U.S. Immigration & Customs Enforcement
   phone: 202-732-4265
   public_liaison:
@@ -1141,39 +1117,31 @@ departments:
     phone:
     - 202-254-4001
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Biologics
-  - Civil rights
-  - Computer technology
-  - Drugs
-  - Education of disadvantaged
-  - Emergency medical services
-  - Fraud
-  - Freedom of information
-  - Grant programs-health
-  - Grant programs-social programs
-  - Health care
-  - Health facilities
-  - Health insurance
-  - Health maintenance organizations (HMO)
-  - Health professions
-  - Health records
-  - Hospitals
-  - Investigations
-  - Kidney diseases
-  - Maternal and child health
-  - Medicaid
-  - Medical devices
-  - Medicare
-  - Packaging and containers
-  - Penalties
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Rural areas
-  - Social security
-  - Transportation
-  - X-rays
+  - biologics
+  - care
+  - child
+  - computer
+  - containers
+  - devices
+  - disadvantaged
+  - diseases
+  - drugs
+  - emergency
+  - fraud
+  - hmo
+  - hospitals
+  - kidney
+  - maintenance
+  - maternal
+  - medicaid
+  - medical
+  - medicare
+  - packaging
+  - programs-social
+  - rural
+  - services
+  - social
+  - x-rays
   name: Office of the Inspector General
   phone: 202-254-4001
   public_liaison:
@@ -1760,58 +1728,49 @@ departments:
     - 866-364-2872
     - 571-227-2300
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Afghanistan
-  - Agriculture
-  - Air carriers
-  - Air taxis
-  - Air traffic control
-  - Air transportation
-  - Aircraft
-  - Airmen
-  - Airports
-  - Alcohol abuse
-  - Aliens
-  - Arms and munitions
-  - Authority delegations (Government agencies)
-  - Aviation safety
-  - Canada
-  - Charter flights
-  - Cuba
-  - Drug abuse
-  - Drug testing
-  - Ethiopia
-  - Explosives
-  - Freight
-  - Freight forwarders
-  - Government employees
-  - Harbors
-  - Hazardous materials transportation
-  - Investigations
-  - Law enforcement
-  - Law enforcement officers
-  - Maritime carriers
-  - Maritime security
-  - Mass transportation
-  - Mexico
-  - Motor carriers
-  - Noise control
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Political candidates
-  - Privacy
-  - Railroad safety
-  - Railroads
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Schools
-  - Seamen
-  - Security measures
-  - Transportation
-  - Vessels
-  - Waterways
-  - Yugoslavia
+  - abuse
+  - afghanistan
+  - air
+  - aircraft
+  - airmen
+  - airports
+  - alcohol
+  - aliens
+  - arms
+  - authority
+  - aviation
+  - canada
+  - candidates
+  - carriers
+  - charter
+  - cuba
+  - delegations
+  - drug
+  - ethiopia
+  - explosives
+  - flights
+  - forwarders
+  - freight
+  - harbors
+  - hazardous
+  - maritime
+  - mass
+  - materials
+  - measures
+  - mexico
+  - munitions
+  - noise
+  - officers
+  - political
+  - railroad
+  - railroads
+  - seamen
+  - security
+  - taxis
+  - testing
+  - traffic
+  - waterways
+  - yugoslavia
   name: Transportation Security Administration
   phone: 866-364-2872
   public_liaison:
@@ -1930,263 +1889,270 @@ emails:
 - foia@hq.dhs.gov
 fax: 202-343-4011
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Advertising
-- Advisory committees
-- Aged
-- Agriculture
-- Air carriers
-- Air pollution control
-- Air traffic control
-- Air transportation
-- Aircraft
-- Airmen
-- Airports
-- Alaska
-- Alcohol abuse
-- Alcohol and alcoholic beverages
-- Aliens
-- American Samoa
-- Anchorage grounds
-- Antidumping
-- Archives and records
-- Armed forces
-- Armed forces reserves
-- Arms and munitions
-- Authority delegations (Government agencies)
-- Aviation safety
-- Benzene
-- Blind
-- Bonds
-- Bridges
-- Broadband
-- Brokers
-- Business and industry
-- Canada
-- Cargo vessels
-- Caribbean Basin initiative
-- Cigars and cigarettes
-- Citizenship and naturalization
-- Civil rights
-- Claims
-- Classified information
-- Coast Guard
-- Coastal zone
-- Coffee
-- Colleges and universities
-- Common carriers
-- Communications
-- Communications equipment
-- Community development
-- Computer technology
-- Confidential business information
-- Conflict of interests
-- Continental shelf
-- Copyright
-- Cotton
-- Countervailing duties
-- Courts
-- Credit
-- Cuba
-- Cultural exchange programs
-- Customs duties and inspection
-- Defense Department
-- Disaster assistance
-- Diving
-- Drug abuse
-- Drug testing
-- Drug traffic control
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Electronic products
-- Elementary and secondary education
-- Employment
-- Endangered and threatened species
-- Environmental protection
-- Equal educational opportunity
-- Equal employment opportunity
-- Executive orders
-- Explosives
-- Exports
-- Federal buildings and facilities
-- Federally affected areas
-- Fire prevention
-- Fishing vessels
-- Flood insurance
-- Foreign currencies
-- Foreign officials
-- Foreign relations
-- Foreign trade zones
-- Fraud
-- Freedom of information
-- Freight
-- Freight forwarders
-- Fruit juices
-- Gases
-- Government contracts
-- Government employees
-- Government procurement
-- Government property management
-- Government publications
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-housing and community development
-- Grant programs-social programs
-- Grant programs-veterans
-- Great Lakes
-- Guam
-- Harbors
-- Hazardous materials transportation
-- Hazardous substances
-- Health care
-- Health professions
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Housing
-- Human research subjects
-- Immigration
-- Imports
-- Income taxes
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Kingman Reef
-- Labeling
-- Labor
-- Labor management relations
-- Labor unions
-- Laboratories
-- Law enforcement
-- Law enforcement officers
-- Lawyers
-- Liquors
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-education
-- Loan programs-energy
-- Loan programs-housing and community development
-- Loan programs-veterans
-- Lobbying
-- Lotteries
-- Manpower training programs
-- Marine mammals
-- Marine resources
-- Marine safety
-- Maritime carriers
-- Maritime security
-- Mass transportation
-- Measurement standards
-- Metals
-- Mexico
-- Midway Islands
-- Migrant labor
-- Military personnel
-- Mortgage insurance
-- Mortgages
-- Motor carriers
-- Motor vehicles
-- National Transportation Safety Board
-- Natural gas
-- Natural resources
-- Navigation (water)
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nuclear vessels
-- Occupational safety and health
-- Oceanographic research vessels
-- Oil and gas exploration
-- Oil imports
-- Oil pollution
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Packaging and containers
-- Passenger vessels
-- Passports and visas
-- Penalties
-- Petroleum
-- Privacy
-- Private schools
-- Puerto Rico
-- Radiation protection
-- Radio
-- Railroad safety
-- Railroads
-- Refugees
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seals and insignia
-- Seamen
-- Search warrants
-- Securities
-- Security measures
-- Seizures and forfeitures
-- Sewage disposal
-- Sex discrimination
-- Signs and symbols
-- Small businesses
-- State and local governments
-- Student aid
-- Students
-- Sugar
-- Surety bonds
-- Taxes
-- Teachers
-- Telecommunications
-- Telephone
-- Terrorism
-- Trade agreements
-- Trademarks
-- Transportation
-- Travel
-- Travel and transportation expenses
-- Travel restrictions
-- Treaties
-- Urban areas
-- Vessels
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Volunteers
-- Wages
-- Wake Island
-- Warehouses
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Waterways
-- Wheat
-- Whistleblowing
-- Wine
-- Women
-- Wool
+- abuse
+- adult
+- advertising
+- advisory
+- affected
+- agreements
+- aid
+- air
+- aircraft
+- airmen
+- airports
+- alaska
+- alcohol
+- alcoholic
+- aliens
+- american
+- anchorage
+- antidumping
+- archives
+- armed
+- arms
+- authority
+- aviation
+- basin
+- benzene
+- beverages
+- blind
+- board
+- bonds
+- bridges
+- broadband
+- brokers
+- businesses
+- canada
+- care
+- cargo
+- caribbean
+- carriers
+- cigarettes
+- cigars
+- citizenship
+- classified
+- coast
+- coastal
+- coffee
+- colleges
+- committees
+- common
+- communications
+- computer
+- confidential
+- construction
+- containers
+- continental
+- control
+- copyright
+- cotton
+- countervailing
+- courts
+- cuba
+- cultural
+- currencies
+- customs
+- defense
+- delegations
+- department
+- disadvantaged
+- disaster
+- disposal
+- diving
+- drug
+- duties
+- electronic
+- elementary
+- endangered
+- equipment
+- exchange
+- executive
+- expenses
+- exploration
+- explosives
+- exports
+- federally
+- fellowships
+- fire
+- fishing
+- flood
+- forces
+- foreign
+- forfeitures
+- forwarders
+- fraud
+- freight
+- fruit
+- gas
+- gases
+- governments
+- great
+- grounds
+- guam
+- guard
+- harbors
+- hazardous
+- highways
+- home
+- homeless
+- hospitals
+- human
+- immigration
+- imports
+- improvement
+- indians-education
+- initiative
+- insignia
+- inspection
+- international
+- inventions
+- island
+- juices
+- kingman
+- labeling
+- labor
+- laboratories
+- lakes
+- lawyers
+- liquors
+- lobbying
+- local
+- lotteries
+- mammals
+- management
+- manpower
+- mariana
+- marine
+- maritime
+- mass
+- materials
+- measurement
+- measures
+- metals
+- mexico
+- midway
+- migrant
+- military
+- mortgage
+- mortgages
+- motor
+- munitions
+- natural
+- naturalization
+- navigation
+- nonprofit
+- northern
+- nuclear
+- occupational
+- oceanographic
+- officers
+- officials
+- oil
+- orders
+- pacific
+- packaging
+- passenger
+- passports
+- patents
+- personnel
+- petroleum
+- pollution
+- prevention
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-housing
+- programs-social
+- programs-veterans
+- publications
+- puerto
+- radiation
+- radio
+- railroad
+- railroads
+- rates
+- reef
+- refugees
+- rehabilitation
+- religious
+- reserves
+- resources
+- restrictions
+- rico
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seals
+- seamen
+- search
+- secondary
+- security
+- seizures
+- sewage
+- sex
+- shelf
+- signs
+- small
+- species
+- standards
+- state
+- student
+- students
+- study
+- subjects
+- substances
+- sugar
+- supply
+- surety
+- symbols
+- taxes
+- teachers
+- technology
+- telecommunications
+- telephone
+- territory
+- terrorism
+- testing
+- threatened
+- trade
+- trademarks
+- traffic
+- training
+- travel
+- treaties
+- treatment
+- trust
+- unions
+- universities
+- urban
+- utilities
+- vehicles
+- vessels
+- veterans
+- virgin
+- visas
+- vocational
+- volunteers
+- wake
+- warehouses
+- warrants
+- waste
+- watersheds
+- waterways
+- wheat
+- whistleblowing
+- wine
+- women
+- wool
+- zone
+- zones
 name: Department of Homeland Security
 phone: 202-343-1743
 public_liaison:

--- a/contacts/data/DNFSB.yaml
+++ b/contacts/data/DNFSB.yaml
@@ -50,10 +50,7 @@ description: The Defense Nuclear Facilities Safety Board reviews the content and
   The board also makes recommendations to the President and Secretary of Energy regarding
   health and safety issues at Defense Nuclear Facilities.
 keywords:
-- Administrative practice and procedure
-- Conflict of interests
-- Courts
-- Government employees
+- courts
 name: Defense Nuclear Facilities Safety Board
 request_time_stats:
   '2008':

--- a/contacts/data/DOC.yaml
+++ b/contacts/data/DOC.yaml
@@ -24,15 +24,16 @@ departments:
   - census.efoia@census.gov
   fax: 301-763-6239
   keywords:
-  - Administrative practice and procedure
-  - Census data
-  - Economic statistics
-  - Exports
-  - Foreign trade
-  - Reporting and recordkeeping requirements
-  - Seals and insignia
-  - State and local governments
-  - Statistics
+  - census
+  - data
+  - economic
+  - exports
+  - governments
+  - insignia
+  - local
+  - seals
+  - state
+  - statistics
   misc:
     Freedom of Information Act Officer:
       name: Michael Toland, Ph.D.
@@ -262,28 +263,14 @@ departments:
     phone:
     - 202-482-3085
   keywords:
-  - Administrative practice and procedure
-  - Aged
-  - Business and industry
-  - Civil rights
-  - Community development
-  - Environmental protection
-  - Equal employment opportunity
-  - Freedom of information
-  - Grant programs
-  - Grant programs-business
-  - Grant programs-housing and community development
-  - Individuals with disabilities
-  - Loan programs-business
-  - Loan programs-housing and community development
-  - Manpower training programs
-  - Mortgages
-  - Organization and functions (Government agencies)
-  - Reporting and recordkeeping requirements
-  - Research
-  - Sex discrimination
-  - Technical assistance
-  - Trade adjustment assistance
+  - adjustment
+  - manpower
+  - mortgages
+  - programs-business
+  - programs-housing
+  - sex
+  - technical
+  - training
   name: Economic Development Administration
   phone: 202-482-3085
   public_liaison:
@@ -392,31 +379,30 @@ departments:
     phone:
     - 202-482-0953
   keywords:
-  - Administrative practice and procedure
-  - Advisory committees
-  - Agricultural commodities
-  - Arms and munitions
-  - Boycotts
-  - Business and industry
-  - Chemicals
-  - Confidential business information
-  - Exports
-  - Foreign trade
-  - Forests and forest products
-  - Government contracts
-  - Horses
-  - Imports
-  - Inventions and patents
-  - Law enforcement
-  - National defense
-  - Penalties
-  - Petroleum
-  - Reporting and recordkeeping requirements
-  - Research
-  - Science and technology
-  - Strategic and critical materials
-  - Terrorism
-  - Treaties
+  - advisory
+  - agricultural
+  - arms
+  - boycotts
+  - chemicals
+  - committees
+  - commodities
+  - confidential
+  - critical
+  - defense
+  - exports
+  - forest
+  - forests
+  - horses
+  - imports
+  - inventions
+  - materials
+  - munitions
+  - patents
+  - petroleum
+  - science
+  - strategic
+  - terrorism
+  - treaties
   name: Bureau of Industry and Security
   phone: 202-482-0953
   public_liaison:
@@ -533,33 +519,35 @@ departments:
     phone:
     - 202-482-7937
   keywords:
-  - Administrative practice and procedure
-  - American Samoa
-  - Antidumping
-  - Australia
-  - Business and industry
-  - Canada
-  - Cheese
-  - Confidential business information
-  - Countervailing duties
-  - Customs duties and inspection
-  - Educational facilities
-  - Emergency powers
-  - Freedom of information
-  - Guam
-  - Imports
-  - Investigations
-  - Marketing quotas
-  - Mexico
-  - Nonprofit organizations
-  - Northern Mariana Islands
-  - Reporting and recordkeeping requirements
-  - Scientific equipment
-  - Steel
-  - Textiles
-  - Trade agreements
-  - Virgin Islands
-  - Watches and jewelry
+  - agreements
+  - american
+  - antidumping
+  - australia
+  - canada
+  - cheese
+  - confidential
+  - countervailing
+  - customs
+  - duties
+  - emergency
+  - equipment
+  - guam
+  - imports
+  - inspection
+  - jewelry
+  - mariana
+  - marketing
+  - mexico
+  - nonprofit
+  - northern
+  - powers
+  - quotas
+  - samoa
+  - scientific
+  - steel
+  - textiles
+  - virgin
+  - watches
   name: International Trade Administration
   phone: 202-482-7937
   public_liaison:
@@ -774,20 +762,17 @@ departments:
   - foia@nist.gov
   fax: 301-975-5301
   keywords:
-  - Administrative practice and procedure
-  - Buildings and facilities
-  - Business and industry
-  - Disaster assistance
-  - Grant programs-science and technology
-  - Imports
-  - Inventions and patents
-  - Investigations
-  - Laboratories
-  - Measurement standards
-  - National Institute of Standards and Technology
-  - Reporting and recordkeeping requirements
-  - Research
-  - Science and technology
+  - disaster
+  - imports
+  - institute
+  - inventions
+  - laboratories
+  - measurement
+  - patents
+  - programs-science
+  - science
+  - standards
+  - technology
   misc:
     FOIA & Privacy Act Officer:
       name: Catherine S. Fletcher
@@ -1013,24 +998,19 @@ departments:
     phone:
     - 202-482-1816
   keywords:
-  - Administrative practice and procedure
-  - Cable television
-  - Classified information
-  - Communications
-  - Communications common carriers
-  - Communications equipment
-  - Defense communications
-  - Electronic products
-  - Federal buildings and facilities
-  - Government employees
-  - Government procurement
-  - Government property
-  - Grant programs
-  - Radio
-  - Satellites
-  - Telecommunications
-  - Telephone
-  - Television
+  - cable
+  - classified
+  - common
+  - communications
+  - defense
+  - electronic
+  - equipment
+  - procurement
+  - radio
+  - satellites
+  - telecommunications
+  - telephone
+  - television
   name: National Telecommunications and Information Administration
   phone: 202-482-1816
   public_liaison:
@@ -1141,71 +1121,69 @@ departments:
   - FOIA@noaa.gov
   fax: 301-713-1169
   keywords:
-  - Administrative practice and procedure
-  - Alaska
-  - American Samoa
-  - Antarctica
-  - Canada
-  - Coast Guard
-  - Coastal zone
-  - Confidential business information
-  - Courts
-  - Disaster assistance
-  - Education
-  - Endangered and threatened species
-  - Environmental protection
-  - Exports
-  - Fish
-  - Fisheries
-  - Fishing
-  - Fishing vessels
-  - Food labeling
-  - Foreign relations
-  - Government employees
-  - Grant programs-business
-  - Guam
-  - Harbors
-  - Hawaiian Natives
-  - Historic preservation
-  - Imports
-  - Income taxes
-  - Indians
-  - Indians-lands
-  - Intergovernmental relations
-  - Labeling
-  - Loan programs
-  - Loan programs-business
-  - Marine mammals
-  - Marine resources
-  - Marine safety
-  - Monuments and memorials
-  - National forests
-  - National parks
-  - Natural resources
-  - Navigation (water)
-  - Northern Mariana Islands
-  - Oil pollution
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Puerto Rico
-  - Reporting and recordkeeping requirements
-  - Research
-  - Russian Federation
-  - Satellites
-  - Science and technology
-  - Scientific equipment
-  - Seafood
-  - Seizures and forfeitures
-  - Space transportation and exploration
-  - Statistics
-  - Transportation
-  - Treaties
-  - Virgin Islands
-  - Water pollution control
-  - Water resources
-  - Waterways
-  - Wildlife
-  - Wildlife refuges
+  - alaska
+  - american
+  - antarctica
+  - canada
+  - coast
+  - coastal
+  - confidential
+  - courts
+  - disaster
+  - endangered
+  - equipment
+  - exploration
+  - exports
+  - federation
+  - fish
+  - fisheries
+  - fishing
+  - food
+  - forests
+  - forfeitures
+  - guam
+  - guard
+  - harbors
+  - hawaiian
+  - historic
+  - imports
+  - indians-lands
+  - labeling
+  - mammals
+  - mariana
+  - marine
+  - memorials
+  - monuments
+  - national
+  - natives
+  - natural
+  - navigation
+  - northern
+  - oil
+  - parks
+  - pollution
+  - preservation
+  - programs-business
+  - puerto
+  - refuges
+  - resources
+  - rico
+  - russian
+  - samoa
+  - satellites
+  - science
+  - scientific
+  - seafood
+  - seizures
+  - space
+  - species
+  - statistics
+  - threatened
+  - treaties
+  - virgin
+  - waterways
+  - wildlife
+  - zone
   misc:
     FOIA Contact:
       name: Wendy Schumacher
@@ -1321,21 +1299,17 @@ departments:
   - efoia@uspto.gov
   fax: 571-501-7335
   keywords:
-  - Administrative practice and procedure
-  - Biologics
-  - Claims
-  - Classified information
-  - Courts
-  - Exports
-  - Foreign relations
-  - Freedom of information
-  - Inventions and patents
-  - Lawyers
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Science and technology
-  - Small businesses
-  - Trademarks
+  - biologics
+  - businesses
+  - classified
+  - courts
+  - exports
+  - inventions
+  - lawyers
+  - patents
+  - science
+  - small
+  - trademarks
   misc:
     FOIA Contact:
       name: Kathryn Siehndel
@@ -1559,274 +1533,294 @@ departments:
   - Efoia@doc.gov
   fax: 202-482-0827
   keywords:
-  - Accountants
-  - Accounting
-  - Administrative practice and procedure
-  - Adult education
-  - Advertising
-  - Advisory committees
-  - Aged
-  - Agricultural commodities
-  - Agricultural research
-  - Agriculture
-  - Aid to Families with Dependent Children
-  - Air carriers
-  - Air rates and fares
-  - Air taxis
-  - Air traffic control
-  - Air transportation
-  - Aircraft
-  - Airmen
-  - Airports
-  - Airspace
-  - Alcohol abuse
-  - Alcohol and alcoholic beverages
-  - Aliens
-  - Alimony
-  - Antitrust
-  - Archives and records
-  - Armed forces
-  - Armed forces reserves
-  - Arms and munitions
-  - Authority delegations (Government agencies)
-  - Aviation safety
-  - Black lung benefits
-  - Blind
-  - Brokers
-  - Buildings and facilities
-  - Buses
-  - Business and industry
-  - Canada
-  - Charter flights
-  - Cheese
-  - Chemicals
-  - Child labor
-  - Child support
-  - Child welfare
-  - Civil defense
-  - Civil rights
-  - Claims
-  - Classified information
-  - Coal
-  - Colleges and universities
-  - Communications equipment
-  - Community development
-  - Computer technology
-  - Concessions
-  - Confidential business information
-  - Conflict of interests
-  - Conscientious objectors
-  - Construction industry
-  - Consumer protection
-  - Continental shelf
-  - Cooperatives
-  - Courts
-  - Credit
-  - Credit unions
-  - Crime
-  - Crop insurance
-  - Cultural exchange programs
-  - Customs duties and inspection
-  - Dairy products
-  - Defense communications
-  - Dental health
-  - Disability benefits
-  - Drug abuse
-  - Drug testing
-  - Drugs
-  - Education
-  - Education of disadvantaged
-  - Education of individuals with disabilities
-  - Educational study programs
-  - Elections
-  - Electric power
-  - Elementary and secondary education
-  - Emergency medical services
-  - Employee benefit plans
-  - Employment
-  - Energy
-  - Environmental impact statements
-  - Environmental protection
-  - Equal access to justice
-  - Equal educational opportunity
-  - Equal employment opportunity
-  - Estates
-  - Excise taxes
-  - Explosives
-  - Exports
-  - Federal buildings and facilities
-  - Federally affected areas
-  - Fire prevention
-  - Firefighters
-  - Fisheries
-  - Food assistance programs
-  - Foreign relations
-  - Forests and forest products
-  - Fraud
-  - Freedom of information
-  - Freight
-  - Gases
-  - Government contracts
-  - Government employees
-  - Government procurement
-  - Government property
-  - Government publications
-  - Grant programs
-  - Grant programs-business
-  - Grant programs-education
-  - Grant programs-health
-  - Grant programs-housing and community development
-  - Grant programs-labor
-  - Grant programs-natural resources
-  - Grant programs-social programs
-  - Grant programs-transportation
-  - Grazing lands
-  - Guam
-  - HIV/AIDS
-  - Hawaiian Natives
-  - Hazardous materials transportation
-  - Hazardous substances
-  - Health
-  - Health care
-  - Health facilities
-  - Health insurance
-  - Health maintenance organizations (HMO)
-  - Health professions
-  - Health records
-  - Highway safety
-  - Highways and roads
-  - Historic preservation
-  - Homeless
-  - Hospitals
-  - Housing
-  - Immigration
-  - Imports
-  - Income taxes
-  - Indemnity payments
-  - Indians
-  - Indians-claims
-  - Indians-lands
-  - Indians-law
-  - Indians-tribal government
-  - Individuals with disabilities
-  - Insurance
-  - Intergovernmental relations
-  - Intermodal transportation
-  - International organizations
-  - Investigations
-  - Investments
-  - Irrigation
-  - Labor
-  - Labor management relations
-  - Laboratories
-  - Land Management Bureau
-  - Law enforcement
-  - Law enforcement officers
-  - Lawyers
-  - Life insurance
-  - Livestock
-  - Loan programs
-  - Loan programs-agriculture
-  - Loan programs-business
-  - Loan programs-communications
-  - Loan programs-energy
-  - Loan programs-health
-  - Loan programs-natural resources
-  - Lobbying
-  - Manpower training programs
-  - Manufactured homes
-  - Mass transportation
-  - Maternal and child health
-  - Medicaid
-  - Medical research
-  - Medicare
-  - Metals
-  - Migrant labor
-  - Military law
-  - Military personnel
-  - Mine safety and health
-  - Mines
-  - Minimum wages
-  - Minority businesses
-  - Motion pictures
-  - Motor vehicle safety
-  - Museums
-  - National defense
-  - National forests
-  - National parks
-  - Natural resources
-  - Navigation (air)
-  - Noise control
-  - Nonprofit organizations
-  - Nuclear energy
-  - Occupational safety and health
-  - Organization and functions (Government agencies)
-  - Pacific Islands Trust Territory
-  - Passenger vessels
-  - Passports and visas
-  - Penalties
-  - Price support programs
-  - Privacy
-  - Public assistance programs
-  - Public health
-  - Public lands
-  - Puerto Rico
-  - Radiation protection
-  - Radio
-  - Railroads
-  - Range management
-  - Real property acquisition
-  - Recordings
-  - Religious discrimination
-  - Relocation assistance
-  - Reporting and recordkeeping requirements
-  - Research
-  - Rural areas
-  - Safety
-  - Science and technology
-  - Seamen
-  - Security measures
-  - Seizures and forfeitures
-  - Sex discrimination
-  - Small businesses
-  - Smoking
-  - Social security
-  - Soil conservation
-  - State and local governments
-  - Statistics
-  - Strategic and critical materials
-  - Student aid
-  - Students
-  - Sunshine Act
-  - Supplemental Security Income (SSI)
-  - Surety bonds
-  - Surface mining
-  - Surplus Government property
-  - Taxes
-  - Teachers
-  - Technical assistance
-  - Telecommunications
-  - Television
-  - Time
-  - Transportation
-  - Transportation Department
-  - Travel restrictions
-  - Trusts and trustees
-  - Truth in lending
-  - Uniform System of Accounts
-  - Virgin Islands
-  - Wages
-  - Waste treatment and disposal
-  - Water resources
-  - Water supply
-  - Waterways
-  - Whistleblowing
-  - Wildlife
-  - Wildlife refuges
-  - Wiretapping and electronic surveillance
-  - Women
-  - Workers' compensation
-  - Youth
+  - abuse
+  - access
+  - accountants
+  - accounts
+  - acquisition
+  - act
+  - adult
+  - advertising
+  - advisory
+  - affected
+  - agricultural
+  - aid
+  - air
+  - aircraft
+  - airmen
+  - airports
+  - airspace
+  - alcohol
+  - alcoholic
+  - aliens
+  - alimony
+  - antitrust
+  - archives
+  - armed
+  - arms
+  - assistance
+  - authority
+  - aviation
+  - benefit
+  - benefits
+  - beverages
+  - black
+  - blind
+  - brokers
+  - bureau
+  - buses
+  - businesses
+  - canada
+  - care
+  - charter
+  - cheese
+  - chemicals
+  - child
+  - children
+  - classified
+  - coal
+  - colleges
+  - committees
+  - commodities
+  - communications
+  - compensation
+  - computer
+  - concessions
+  - confidential
+  - conscientious
+  - conservation
+  - construction
+  - consumer
+  - continental
+  - cooperatives
+  - courts
+  - credit
+  - crime
+  - critical
+  - crop
+  - cultural
+  - customs
+  - dairy
+  - defense
+  - delegations
+  - dental
+  - department
+  - dependent
+  - disability
+  - disadvantaged
+  - disposal
+  - drug
+  - drugs
+  - duties
+  - elections
+  - electronic
+  - elementary
+  - emergency
+  - employee
+  - energy
+  - equipment
+  - estates
+  - exchange
+  - excise
+  - explosives
+  - exports
+  - families
+  - fares
+  - federally
+  - fire
+  - firefighters
+  - fisheries
+  - flights
+  - food
+  - forces
+  - forest
+  - forests
+  - forfeitures
+  - fraud
+  - freight
+  - gases
+  - governments
+  - grazing
+  - guam
+  - hawaiian
+  - hazardous
+  - highway
+  - highways
+  - historic
+  - hiv/aids
+  - hmo
+  - homeless
+  - homes
+  - hospitals
+  - immigration
+  - impact
+  - imports
+  - income
+  - indemnity
+  - indians-claims
+  - indians-lands
+  - indians-law
+  - indians-tribal
+  - industry
+  - inspection
+  - intermodal
+  - international
+  - investments
+  - irrigation
+  - justice
+  - labor
+  - laboratories
+  - land
+  - lands
+  - law
+  - lawyers
+  - lending
+  - life
+  - livestock
+  - lobbying
+  - local
+  - lung
+  - maintenance
+  - management
+  - manpower
+  - manufactured
+  - mass
+  - materials
+  - maternal
+  - measures
+  - medicaid
+  - medical
+  - medicare
+  - metals
+  - migrant
+  - military
+  - mine
+  - mines
+  - minimum
+  - mining
+  - minority
+  - motion
+  - munitions
+  - museums
+  - national
+  - natives
+  - natural
+  - navigation
+  - noise
+  - nonprofit
+  - nuclear
+  - objectors
+  - occupational
+  - officers
+  - organizations
+  - pacific
+  - parks
+  - passenger
+  - passports
+  - payments
+  - personnel
+  - pictures
+  - plans
+  - preservation
+  - prevention
+  - price
+  - procurement
+  - products
+  - programs-agriculture
+  - programs-business
+  - programs-communications
+  - programs-education
+  - programs-energy
+  - programs-health
+  - programs-labor
+  - programs-natural
+  - programs-social
+  - programs-transportation
+  - property
+  - public
+  - publications
+  - puerto
+  - radiation
+  - radio
+  - railroads
+  - range
+  - rates
+  - real
+  - recordings
+  - records
+  - refuges
+  - religious
+  - relocation
+  - reserves
+  - resources
+  - restrictions
+  - rico
+  - roads
+  - rural
+  - science
+  - seamen
+  - secondary
+  - security
+  - seizures
+  - services
+  - sex
+  - shelf
+  - small
+  - smoking
+  - social
+  - soil
+  - ssi
+  - state
+  - statements
+  - statistics
+  - strategic
+  - student
+  - students
+  - study
+  - substances
+  - sunshine
+  - supplemental
+  - supply
+  - support
+  - surety
+  - surface
+  - surplus
+  - surveillance
+  - system
+  - taxes
+  - taxis
+  - teachers
+  - technical
+  - technology
+  - telecommunications
+  - television
+  - territory
+  - testing
+  - time
+  - traffic
+  - training
+  - travel
+  - treatment
+  - trust
+  - trustees
+  - trusts
+  - truth
+  - uniform
+  - unions
+  - universities
+  - vehicle
+  - virgin
+  - visas
+  - wages
+  - waste
+  - waterways
+  - welfare
+  - whistleblowing
+  - wildlife
+  - wiretapping
+  - women
+  - workers'
+  - youth
   misc:
     FOIA Contact, Immediate Office of the Secretary, Office of Privacy and Open Government:
       name: Bobbie Parsons
@@ -1935,216 +1929,214 @@ emails:
 - Efoia@doc.gov
 fax: 202-482-0827
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Advisory committees
-- Aged
-- Agricultural commodities
-- Agriculture
-- Air carriers
-- Airports
-- Alaska
-- American Samoa
-- Antarctica
-- Antidumping
-- Arms and munitions
-- Biologics
-- Blind
-- Boycotts
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Cable television
-- Canada
-- Census data
-- Cheese
-- Chemicals
-- Civil rights
-- Claims
-- Classified information
-- Coast Guard
-- Coastal zone
-- Colleges and universities
-- Communications
-- Communications common carriers
-- Communications equipment
-- Community development
-- Confidential business information
-- Conflict of interests
-- Copyright
-- Countervailing duties
-- Courts
-- Credit
-- Cultural exchange programs
-- Customs duties and inspection
-- Defense communications
-- Disaster assistance
-- Drug abuse
-- Economic statistics
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Electronic products
-- Elementary and secondary education
-- Emergency powers
-- Employment
-- Endangered and threatened species
-- Environmental protection
-- Equal educational opportunity
-- Equal employment opportunity
-- Exports
-- Federal buildings and facilities
-- Federally affected areas
-- Fish
-- Fisheries
-- Fishing
-- Fishing vessels
-- Food labeling
-- Foreign investments in United States
-- Foreign relations
-- Foreign trade
-- Foreign trade zones
-- Forests and forest products
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Grant programs
-- Grant programs-business
-- Grant programs-education
-- Grant programs-health
-- Grant programs-housing and community development
-- Grant programs-science and technology
-- Grant programs-social programs
-- Guam
-- Harbors
-- Hawaiian Natives
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Historic preservation
-- Home improvement
-- Homeless
-- Horses
-- Hospitals
-- Hostages
-- Human research subjects
-- Imports
-- Income taxes
-- Indians
-- Indians-education
-- Indians-lands
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Labeling
-- Laboratories
-- Law enforcement
-- Lawyers
-- Lebanon
-- Libraries
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-business
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Marine mammals
-- Marine resources
-- Marine safety
-- Maritime carriers
-- Marketing quotas
-- Mass transportation
-- Measurement standards
-- Migrant labor
-- Monuments and memorials
-- Mortgage insurance
-- Mortgages
-- National Institute of Standards and Technology
-- National defense
-- National forests
-- National parks
-- Natural resources
-- Navigation (water)
-- Nonprofit organizations
-- Northern Mariana Islands
-- Oil pollution
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Penalties
-- Petroleum
-- Privacy
-- Private schools
-- Puerto Rico
-- Radio
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Russian Federation
-- Satellites
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Scientific equipment
-- Seafood
-- Seals and insignia
-- Securities
-- Seizures and forfeitures
-- Sex discrimination
-- Small businesses
-- Space transportation and exploration
-- State and local governments
-- Statistics
-- Steel
-- Strategic and critical materials
-- Student aid
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Television
-- Terrorism
-- Textiles
-- Trade adjustment assistance
-- Trademarks
-- Transportation
-- Treaties
-- United States investments abroad
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Watches and jewelry
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Waterways
-- Wildlife
-- Wildlife refuges
-- Women
+- abroad
+- adjustment
+- adult
+- advisory
+- affected
+- agricultural
+- aid
+- airports
+- alaska
+- american
+- antarctica
+- antidumping
+- arms
+- assistance
+- biologics
+- blind
+- boycotts
+- broadband
+- businesses
+- cable
+- canada
+- carriers
+- census
+- cheese
+- chemicals
+- classified
+- coast
+- coastal
+- colleges
+- committees
+- commodities
+- common
+- communications
+- confidential
+- construction
+- copyright
+- countervailing
+- courts
+- critical
+- cultural
+- customs
+- data
+- defense
+- disadvantaged
+- disaster
+- disposal
+- duties
+- economic
+- electronic
+- elementary
+- emergency
+- endangered
+- equipment
+- exchange
+- exploration
+- exports
+- federally
+- federation
+- fellowships
+- fish
+- fisheries
+- fishing
+- food
+- foreign
+- forest
+- forests
+- forfeitures
+- governments
+- guam
+- guard
+- harbors
+- hawaiian
+- highways
+- historic
+- home
+- homeless
+- horses
+- hospitals
+- hostages
+- human
+- imports
+- improvement
+- indians-education
+- indians-lands
+- insignia
+- inspection
+- institute
+- international
+- inventions
+- investments
+- iraq
+- jewelry
+- kuwait
+- labeling
+- laboratories
+- lawyers
+- lebanon
+- libraries
+- local
+- mammals
+- manpower
+- mariana
+- marine
+- maritime
+- marketing
+- mass
+- materials
+- measurement
+- memorials
+- migrant
+- monuments
+- mortgage
+- mortgages
+- munitions
+- national
+- natives
+- natural
+- navigation
+- nonprofit
+- northern
+- oil
+- pacific
+- parks
+- patents
+- petroleum
+- pollution
+- powers
+- preservation
+- private
+- procurement
+- products
+- programs-agriculture
+- programs-business
+- programs-communications
+- programs-education
+- programs-energy
+- programs-housing
+- programs-science
+- programs-social
+- puerto
+- quotas
+- radio
+- railroads
+- rates
+- refuges
+- rehabilitation
+- religious
+- resources
+- rico
+- roads
+- rural
+- russian
+- samoa
+- satellites
+- scholarships
+- school
+- schools
+- science
+- scientific
+- seafood
+- seals
+- secondary
+- seizures
+- sex
+- small
+- space
+- species
+- standards
+- state
+- states
+- statistics
+- steel
+- strategic
+- student
+- study
+- subjects
+- supply
+- teachers
+- technical
+- technology
+- telecommunications
+- telephone
+- television
+- territory
+- terrorism
+- textiles
+- threatened
+- trade
+- trademarks
+- training
+- treaties
+- treatment
+- trust
+- united
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watches
+- watersheds
+- waterways
+- wildlife
+- women
+- zone
+- zones
 name: Department of Commerce
 phone: 202-482-3258
 public_liaison:

--- a/contacts/data/DOE.yaml
+++ b/contacts/data/DOE.yaml
@@ -1160,11 +1160,9 @@ departments:
     phone:
     - 720-962-7010
   keywords:
-  - Electric power
-  - Electric utilities
-  - Energy
-  - Energy conservation
-  - Reporting and recordkeeping requirements
+  - conservation
+  - energy
+  - utilities
   name: Western Area Power Administration
   phone: 720-962-7010
   public_liaison:
@@ -1387,199 +1385,189 @@ description: The Department of Energy manages the United States' nuclear infrast
   and administers the country's energy policy. The Department of Energy also funds
   scientific research in the field.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Air transportation
-- Aircraft
-- Airports
-- Alaska
-- Alcohol abuse
-- American Samoa
-- Antitrust
-- Authority delegations (Government agencies)
-- Beryllium
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Civil defense
-- Civil rights
-- Claims
-- Classified information
-- Colleges and universities
-- Communications
-- Community development
-- Conduct standards
-- Confidential business information
-- Conflict of interests
-- Continental shelf
-- Copyright
-- Credit
-- Cultural exchange programs
-- Dams
-- Drug abuse
-- Drug testing
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power plants
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Energy
-- Energy conservation
-- Engineers
-- Environmental impact statements
-- Environmental protection
-- Equal access to justice
-- Equal educational opportunity
-- Equal employment opportunity
-- Exports
-- Federal buildings and facilities
-- Federally affected areas
-- Flood plains
-- Foreign relations
-- Fraud
-- Freedom of information
-- Fuel economy
-- Gases
-- Gasoline
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-energy
-- Grant programs-health
-- Grant programs-housing and community development
-- Grant programs-social programs
-- Guam
-- Hazardous materials transportation
-- Hazardous substances
-- Health
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Historic preservation
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Household appliances
-- Housing
-- Housing standards
-- Human research subjects
-- Imports
-- Income taxes
-- Indians
-- Indians-education
-- Indians-lands
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Law enforcement
-- Lawyers
-- Lebanon
-- Legal services
-- Lie detector tests
-- Livestock
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Lobbying
-- Lung diseases
-- Manpower training programs
-- Marital status discrimination
-- Maritime carriers
-- Mass transportation
-- Medical research
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Motor vehicles
-- National defense
-- Natural gas
-- Natural resources
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nuclear energy
-- Nuclear materials
-- Nuclear power plants and reactors
-- Occupational safety and health
-- Oil and gas reserves
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Penalties
-- Petroleum
-- Pipelines
-- Plutonium
-- Privacy
-- Private schools
-- Public health
-- Public lands
-- Radiation protection
-- Radioactive materials
-- Railroads
-- Reclamation
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Scientists
-- Seals and insignia
-- Securities
-- Security measures
-- Sex discrimination
-- Small businesses
-- Solar energy
-- State and local governments
-- Strategic and critical materials
-- Student aid
-- Sunshine Act
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Traffic regulations
-- Treaties
-- Uniform System of Accounts
-- Uranium
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Whistleblowing
-- Women
-- Workers' compensation
+- abuse
+- access
+- accounts
+- act
+- adult
+- affected
+- aid
+- aircraft
+- airports
+- alaska
+- alcohol
+- american
+- antitrust
+- appliances
+- authority
+- beryllium
+- blind
+- broadband
+- businesses
+- classified
+- colleges
+- compensation
+- conduct
+- confidential
+- conservation
+- construction
+- continental
+- copyright
+- critical
+- cultural
+- dams
+- defense
+- delegations
+- detector
+- disadvantaged
+- discrimination
+- diseases
+- disposal
+- drug
+- economy
+- elementary
+- energy
+- engineers
+- exchange
+- exports
+- federally
+- fellowships
+- flood
+- fraud
+- fuel
+- gas
+- gases
+- gasoline
+- governments
+- guam
+- hazardous
+- highways
+- historic
+- home
+- homeless
+- hospitals
+- hostages
+- household
+- housing
+- human
+- impact
+- imports
+- improvement
+- indians-education
+- indians-lands
+- insignia
+- international
+- inventions
+- iraq
+- justice
+- kuwait
+- lands
+- lawyers
+- lebanon
+- legal
+- lie
+- livestock
+- lobbying
+- local
+- lung
+- manpower
+- mariana
+- marital
+- maritime
+- mass
+- materials
+- measures
+- medical
+- migrant
+- mortgage
+- mortgages
+- natural
+- nonprofit
+- northern
+- nuclear
+- occupational
+- oil
+- pacific
+- patents
+- petroleum
+- pipelines
+- plains
+- plants
+- plutonium
+- power
+- preservation
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-housing
+- programs-social
+- public
+- radiation
+- radioactive
+- railroads
+- rates
+- reactors
+- reclamation
+- regulations
+- rehabilitation
+- religious
+- reserves
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- scientists
+- seals
+- secondary
+- services
+- sex
+- shelf
+- small
+- solar
+- standards
+- state
+- statements
+- status
+- strategic
+- student
+- study
+- subjects
+- substances
+- sunshine
+- supply
+- system
+- teachers
+- technical
+- telecommunications
+- telephone
+- territory
+- testing
+- tests
+- traffic
+- training
+- treaties
+- treatment
+- trust
+- uniform
+- universities
+- uranium
+- urban
+- utilities
+- vehicles
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- whistleblowing
+- women
+- workers'
 name: Department of Energy
 request_time_stats:
   '2008':

--- a/contacts/data/DOI.yaml
+++ b/contacts/data/DOI.yaml
@@ -22,45 +22,36 @@ departments:
     phone:
     - 202-208-4174
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Alaska
-  - Buildings and facilities
-  - Child welfare
-  - Claims
-  - Courts
-  - Educational facilities
-  - Employment
-  - Equal access to justice
-  - Estates
-  - Government contracts
-  - Government property management
-  - Grant programs-Indians
-  - Grant programs-housing and community development
-  - Grant programs-social programs
-  - Grazing lands
-  - Health care
-  - Highways and roads
-  - Housing
-  - Indians
-  - Indians-business and finance
-  - Indians-claims
-  - Indians-education
-  - Indians-lands
-  - Indians-law
-  - Indians-tribal government
-  - Irrigation
-  - Law enforcement
-  - Lawyers
-  - Livestock
-  - Penalties
-  - Public assistance programs
-  - Reporting and recordkeeping requirements
-  - Rights-of-way
-  - School construction
-  - Schools
-  - Students
-  - Trusts and trustees
+  - access
+  - alaska
+  - care
+  - child
+  - construction
+  - courts
+  - estates
+  - finance
+  - grazing
+  - highways
+  - indians-business
+  - indians-claims
+  - indians-education
+  - indians-lands
+  - indians-law
+  - indians-tribal
+  - irrigation
+  - justice
+  - lands
+  - lawyers
+  - livestock
+  - programs-indians
+  - programs-social
+  - rights-of-way
+  - roads
+  - school
+  - students
+  - trustees
+  - trusts
+  - welfare
   name: Bureau of Indian Affairs
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -159,57 +150,59 @@ departments:
     phone:
     - 202-912-7650
   keywords:
-  - Administrative practice and procedure
-  - Airports
-  - Airspace
-  - Alaska
-  - Antitrust
-  - Archives and records
-  - Bonds
-  - Coal
-  - Common carriers
-  - Communications
-  - Continental shelf
-  - Electric power
-  - Environmental impact statements
-  - Environmental protection
-  - Federal Energy Regulatory Commission
-  - Forests and forest products
-  - Geothermal energy
-  - Government contracts
-  - Grant programs-natural resources
-  - Grazing lands
-  - Highways and roads
-  - Homesteads
-  - Hydrocarbons
-  - Indians
-  - Indians-lands
-  - Intergovernmental relations
-  - Land Management Bureau
-  - Law enforcement
-  - Livestock
-  - Loan programs-natural resources
-  - Mineral royalties
-  - Mines
-  - Monuments and memorials
-  - National forests
-  - National parks
-  - Navigation (air)
-  - Oil and gas exploration
-  - Oil and gas reserves
-  - Penalties
-  - Phosphate
-  - Pipelines
-  - Public lands
-  - Range management
-  - Reporting and recordkeeping requirements
-  - Seashores
-  - Sulfur
-  - Surety bonds
-  - Traffic regulations
-  - Water resources
-  - Wilderness areas
-  - Wildlife
+  - airports
+  - airspace
+  - alaska
+  - antitrust
+  - archives
+  - bonds
+  - bureau
+  - coal
+  - commission
+  - common
+  - continental
+  - energy
+  - exploration
+  - forest
+  - forests
+  - gas
+  - geothermal
+  - grazing
+  - highways
+  - homesteads
+  - hydrocarbons
+  - impact
+  - indians-lands
+  - land
+  - lands
+  - livestock
+  - management
+  - memorials
+  - mineral
+  - mines
+  - monuments
+  - national
+  - navigation
+  - oil
+  - parks
+  - phosphate
+  - pipelines
+  - programs-natural
+  - range
+  - regulations
+  - regulatory
+  - reserves
+  - resources
+  - roads
+  - royalties
+  - seashores
+  - shelf
+  - statements
+  - sulfur
+  - surety
+  - traffic
+  - wilderness
+  - wildlife
   name: Bureau of Land Management
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -318,31 +311,25 @@ departments:
   - BOEMFOIA@boem.gov
   fax: 703-787-1209
   keywords:
-  - Administrative practice and procedure
-  - Civil rights
-  - Coastal zone
-  - Continental shelf
-  - Electric power
-  - Energy
-  - Environmental impact statements
-  - Environmental protection
-  - Freedom of information
-  - Government contracts
-  - Indians-lands
-  - Intergovernmental relations
-  - Investigations
-  - Marine resources
-  - Mineral royalties
-  - Natural resources
-  - Oil and gas exploration
-  - Oil pollution
-  - Penalties
-  - Pipelines
-  - Public lands
-  - Reporting and recordkeeping requirements
-  - Research
-  - Solar energy
-  - Surety bonds
+  - coastal
+  - continental
+  - energy
+  - exploration
+  - gas
+  - impact
+  - indians-lands
+  - lands
+  - marine
+  - mineral
+  - natural
+  - oil
+  - pipelines
+  - royalties
+  - shelf
+  - solar
+  - statements
+  - surety
+  - zone
   misc:
     FOIA Contact:
       name: Rosemary Melendy
@@ -413,23 +400,19 @@ departments:
     - 303-445-2056
     - 888-231-7779
   keywords:
-  - Administrative practice and procedure
-  - Agriculture
-  - Dams
-  - Endangered and threatened species
-  - Irrigation
-  - Law enforcement
-  - Natural resources
-  - Penalties
-  - Public lands
-  - Reclamation
-  - Reporting and recordkeeping requirements
-  - Reservoirs
-  - Rural areas
-  - Security measures
-  - Water resources
-  - Water supply
-  - Watersheds
+  - dams
+  - endangered
+  - irrigation
+  - lands
+  - measures
+  - natural
+  - reclamation
+  - reservoirs
+  - rural
+  - species
+  - supply
+  - threatened
+  - watersheds
   name: Bureau of Reclamation
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -538,25 +521,19 @@ departments:
   - BSEEFOIA@bsee.gov
   fax: 703-787-1207
   keywords:
-  - Administrative practice and procedure
-  - Civil rights
-  - Continental shelf
-  - Environmental impact statements
-  - Environmental protection
-  - Freedom of information
-  - Government contracts
-  - Indians-lands
-  - Intergovernmental relations
-  - Investigations
-  - Mineral royalties
-  - Oil and gas exploration
-  - Oil pollution
-  - Penalties
-  - Pipelines
-  - Public lands
-  - Reporting and recordkeeping requirements
-  - Research
-  - Surety bonds
+  - continental
+  - exploration
+  - gas
+  - impact
+  - indians-lands
+  - lands
+  - mineral
+  - oil
+  - pipelines
+  - royalties
+  - shelf
+  - statements
+  - surety
   misc:
     FOIA Contact:
       name: Debbie Kimball
@@ -623,67 +600,63 @@ departments:
     phone:
     - 703-358-2470
   keywords:
-  - Administrative practice and procedure
-  - Alaska
-  - Alcohol and alcoholic beverages
-  - Animal welfare
-  - Animals
-  - Business and industry
-  - Civil rights
-  - Coastal zone
-  - Concessions
-  - Education
-  - Endangered and threatened species
-  - Environmental protection
-  - Equal employment opportunity
-  - Exports
-  - Fish
-  - Fisheries
-  - Fishing
-  - Foreign officials
-  - Foreign trade
-  - Grant programs
-  - Grant programs-natural resources
-  - Grant programs-recreation
-  - Harbors
-  - Historic preservation
-  - Hunting
-  - Imports
-  - Indians
-  - Intergovernmental relations
-  - Intermodal transportation
-  - Labeling
-  - Law enforcement
-  - Marine mammals
-  - Marine resources
-  - Marine safety
-  - Monuments and memorials
-  - Motion pictures
-  - National forests
-  - National parks
-  - Natural resources
-  - Navigation (water)
-  - Oil and gas exploration
-  - Organization and functions (Government agencies)
-  - Plants
-  - Public lands
-  - Real property acquisition
-  - Recordings
-  - Reporting and recordkeeping requirements
-  - Research
-  - Rivers
-  - Safety
-  - Sewage disposal
-  - Signs and symbols
-  - Television
-  - Transportation
-  - Treaties
-  - Vessels
-  - Water pollution control
-  - Water resources
-  - Waterways
-  - Wildlife
-  - Wildlife refuges
+  - acquisition
+  - alaska
+  - alcohol
+  - alcoholic
+  - animal
+  - animals
+  - beverages
+  - coastal
+  - concessions
+  - disposal
+  - endangered
+  - exploration
+  - exports
+  - fish
+  - fisheries
+  - fishing
+  - forests
+  - gas
+  - harbors
+  - historic
+  - hunting
+  - imports
+  - intermodal
+  - labeling
+  - lands
+  - mammals
+  - marine
+  - memorials
+  - monuments
+  - motion
+  - national
+  - natural
+  - navigation
+  - officials
+  - oil
+  - parks
+  - pictures
+  - plants
+  - preservation
+  - programs-natural
+  - programs-recreation
+  - real
+  - recordings
+  - refuges
+  - resources
+  - rivers
+  - sewage
+  - signs
+  - species
+  - symbols
+  - television
+  - threatened
+  - treaties
+  - waterways
+  - welfare
+  - wildlife
+  - zone
   name: U.S. Fish and Wildlife Service
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -888,40 +861,40 @@ departments:
   foia_officer:
     name: Charis Wilson
   keywords:
-  - Alaska
-  - Alcohol and alcoholic beverages
-  - Archives and records
-  - Business and industry
-  - Cemeteries
-  - Civil rights
-  - Concessions
-  - District of Columbia
-  - Environmental protection
-  - Equal employment opportunity
-  - Foreign relations
-  - Government contracts
-  - Grant programs-natural resources
-  - Historic preservation
-  - Hunting
-  - Income taxes
-  - Indians-lands
-  - Indians-tribal government
-  - Marine safety
-  - Military personnel
-  - Motion pictures
-  - Museums
-  - National parks
-  - Penalties
-  - Public lands
-  - Recordings
-  - Reporting and recordkeeping requirements
-  - Signs and symbols
-  - Small businesses
-  - Television
-  - Traffic regulations
-  - Transportation
-  - Veterans
-  - Wildlife refuges
+  - alaska
+  - alcohol
+  - alcoholic
+  - archives
+  - beverages
+  - businesses
+  - cemeteries
+  - columbia
+  - concessions
+  - district
+  - historic
+  - hunting
+  - indians-lands
+  - indians-tribal
+  - lands
+  - marine
+  - military
+  - motion
+  - museums
+  - parks
+  - personnel
+  - pictures
+  - preservation
+  - programs-natural
+  - recordings
+  - refuges
+  - regulations
+  - signs
+  - small
+  - symbols
+  - television
+  - traffic
+  - veterans
+  - wildlife
   name: National Park Service
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1128,41 +1101,42 @@ departments:
   - os_foia@ios.doi.gov
   fax: 303-445-4288
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Authority delegations (Government agencies)
-  - Civil rights
-  - Coal
-  - Continental shelf
-  - Electronic funds transfers
-  - Environmental impact statements
-  - Environmental protection
-  - Equal access to justice
-  - Estates
-  - Geothermal energy
-  - Government contracts
-  - Grazing lands
-  - Indians
-  - Indians-lands
-  - Intergovernmental relations
-  - Investigations
-  - Lawyers
-  - Mineral resources
-  - Mineral royalties
-  - Mines
-  - Natural gas
-  - Oil and gas exploration
-  - Penalties
-  - Petroleum
-  - Phosphate
-  - Pipelines
-  - Public lands
-  - Reporting and recordkeeping requirements
-  - Small businesses
-  - Sulfur
-  - Surety bonds
-  - Surface mining
-  - Whistleblowing
+  - access
+  - authority
+  - businesses
+  - coal
+  - continental
+  - delegations
+  - electronic
+  - energy
+  - estates
+  - exploration
+  - funds
+  - gas
+  - geothermal
+  - grazing
+  - impact
+  - indians-lands
+  - justice
+  - lands
+  - lawyers
+  - mineral
+  - mines
+  - mining
+  - natural
+  - oil
+  - petroleum
+  - phosphate
+  - pipelines
+  - royalties
+  - shelf
+  - small
+  - statements
+  - sulfur
+  - surety
+  - surface
+  - transfers
+  - whistleblowing
   misc:
     FOIA Contact:
       name: Richard Lopez
@@ -1459,244 +1433,246 @@ description: The Department of the Interior manages public lands and minerals, n
   tribes and Native Alaskans. Additionally, Interior is responsible for endangered
   species conservation and other environmental conservation efforts.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Airports
-- Airspace
-- Alaska
-- Alcohol and alcoholic beverages
-- American Samoa
-- Animal welfare
-- Animals
-- Antitrust
-- Archives and records
-- Authority delegations (Government agencies)
-- Blind
-- Bonds
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Cemeteries
-- Child welfare
-- Civil rights
-- Claims
-- Classified information
-- Coal
-- Coastal zone
-- Colleges and universities
-- Common carriers
-- Communications
-- Community development
-- Concessions
-- Continental shelf
-- Copyright
-- Courts
-- Credit
-- Cultural exchange programs
-- Customs duties and inspection
-- Dams
-- District of Columbia
-- Drug abuse
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Electronic funds transfers
-- Elementary and secondary education
-- Employment
-- Endangered and threatened species
-- Energy
-- Environmental impact statements
-- Environmental protection
-- Equal access to justice
-- Equal educational opportunity
-- Equal employment opportunity
-- Estates
-- Exports
-- Federal Energy Regulatory Commission
-- Federal buildings and facilities
-- Federally affected areas
-- Fire prevention
-- Fish
-- Fisheries
-- Fishing
-- Foreign officials
-- Foreign relations
-- Foreign trade
-- Forests and forest products
-- Freedom of information
-- Gambling
-- Geothermal energy
-- Government contracts
-- Government employees
-- Government procurement
-- Government property management
-- Grant programs
-- Grant programs-Indians
-- Grant programs-education
-- Grant programs-health
-- Grant programs-housing and community development
-- Grant programs-natural resources
-- Grant programs-recreation
-- Grant programs-social programs
-- Grazing lands
-- Guam
-- Harbors
-- Hawaiian Natives
-- Health care
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Historic preservation
-- Home improvement
-- Homeless
-- Homesteads
-- Hospitals
-- Hostages
-- Housing
-- Human research subjects
-- Hunting
-- Hydrocarbons
-- Imports
-- Income taxes
-- Indians
-- Indians-arts and crafts
-- Indians-business and finance
-- Indians-claims
-- Indians-education
-- Indians-lands
-- Indians-law
-- Indians-tribal government
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- Intermodal transportation
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Irrigation
-- Kuwait
-- Labeling
-- Land Management Bureau
-- Law enforcement
-- Lawyers
-- Lebanon
-- Livestock
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Loan programs-natural resources
-- Manpower training programs
-- Marine mammals
-- Marine resources
-- Marine safety
-- Marketing quotas
-- Mass transportation
-- Migrant labor
-- Military personnel
-- Mineral resources
-- Mineral royalties
-- Minerals Management Service
-- Mines
-- Monuments and memorials
-- Mortgage insurance
-- Mortgages
-- Motion pictures
-- Museums
-- National forests
-- National parks
-- Natural gas
-- Natural resources
-- Navigation (air)
-- Navigation (water)
-- Nonprofit organizations
-- Northern Mariana Islands
-- Oil and gas exploration
-- Oil and gas reserves
-- Oil pollution
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Penalties
-- Petroleum
-- Phosphate
-- Pipelines
-- Plants
-- Privacy
-- Private schools
-- Public assistance programs
-- Public lands
-- Railroads
-- Range management
-- Real property acquisition
-- Reclamation
-- Recordings
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Reservoirs
-- Rights-of-way
-- Rivers
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seashores
-- Securities
-- Security measures
-- Sewage disposal
-- Sex discrimination
-- Signs and symbols
-- Small businesses
-- Solar energy
-- State and local governments
-- Student aid
-- Students
-- Sulfur
-- Surety bonds
-- Surface mining
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Television
-- Trademarks
-- Traffic regulations
-- Transportation
-- Treaties
-- Trusts and trustees
-- Underground mining
-- Urban areas
-- Vessels
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Waste treatment and disposal
-- Watches and jewelry
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Waterways
-- Whistleblowing
-- Wilderness areas
-- Wildlife
-- Wildlife refuges
-- Women
+- access
+- acquisition
+- adult
+- affected
+- aid
+- airports
+- airspace
+- alaska
+- alcohol
+- alcoholic
+- american
+- animal
+- animals
+- antitrust
+- archives
+- authority
+- beverages
+- blind
+- bonds
+- broadband
+- bureau
+- businesses
+- care
+- cemeteries
+- child
+- classified
+- coal
+- coastal
+- colleges
+- columbia
+- commission
+- common
+- concessions
+- construction
+- continental
+- copyright
+- courts
+- crafts
+- cultural
+- customs
+- dams
+- delegations
+- disadvantaged
+- disposal
+- district
+- duties
+- electronic
+- elementary
+- endangered
+- energy
+- estates
+- exchange
+- exploration
+- exports
+- federal
+- federally
+- fellowships
+- finance
+- fire
+- fish
+- fisheries
+- fishing
+- forest
+- forests
+- funds
+- gambling
+- gas
+- geothermal
+- governments
+- grazing
+- guam
+- harbors
+- hawaiian
+- highways
+- historic
+- home
+- homeless
+- homesteads
+- hospitals
+- hostages
+- human
+- hunting
+- hydrocarbons
+- impact
+- imports
+- improvement
+- indians-arts
+- indians-business
+- indians-claims
+- indians-education
+- indians-lands
+- indians-law
+- indians-tribal
+- inspection
+- intermodal
+- international
+- inventions
+- iraq
+- irrigation
+- jewelry
+- justice
+- kuwait
+- labeling
+- land
+- lands
+- lawyers
+- lebanon
+- livestock
+- local
+- mammals
+- management
+- manpower
+- mariana
+- marine
+- marketing
+- mass
+- measures
+- memorials
+- migrant
+- military
+- mineral
+- minerals
+- mines
+- mining
+- monuments
+- mortgage
+- mortgages
+- motion
+- museums
+- national
+- natives
+- natural
+- navigation
+- nonprofit
+- northern
+- officials
+- oil
+- pacific
+- parks
+- patents
+- personnel
+- petroleum
+- phosphate
+- pictures
+- pipelines
+- plants
+- pollution
+- preservation
+- prevention
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-housing
+- programs-indians
+- programs-natural
+- programs-recreation
+- programs-social
+- public
+- quotas
+- railroads
+- range
+- rates
+- real
+- reclamation
+- recordings
+- refuges
+- regulations
+- regulatory
+- rehabilitation
+- religious
+- reserves
+- reservoirs
+- resources
+- rights-of-way
+- rivers
+- roads
+- royalties
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seashores
+- secondary
+- service
+- sewage
+- sex
+- shelf
+- signs
+- small
+- solar
+- species
+- state
+- statements
+- student
+- students
+- study
+- subjects
+- sulfur
+- supply
+- surety
+- surface
+- symbols
+- teachers
+- technical
+- telecommunications
+- telephone
+- television
+- territory
+- threatened
+- trademarks
+- traffic
+- training
+- transfers
+- treaties
+- treatment
+- trust
+- trustees
+- trusts
+- underground
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watches
+- watersheds
+- waterways
+- welfare
+- whistleblowing
+- wilderness
+- wildlife
+- women
+- zone
 name: Department of Interior
 request_time_stats:
   '2008':

--- a/contacts/data/DOJ.yaml
+++ b/contacts/data/DOJ.yaml
@@ -433,71 +433,79 @@ departments:
   - foiamail@atf.gov
   fax: 202-648-9619
   keywords:
-  - Administrative practice and procedure
-  - Advertising
-  - Aircraft
-  - Alcohol and alcoholic beverages
-  - Antitrust
-  - Armed forces
-  - Arms and munitions
-  - Arson
-  - Authority delegations (Government agencies)
-  - Bankruptcy
-  - Beer
-  - Caribbean Basin initiative
-  - Chemicals
-  - Cigars and cigarettes
-  - Claims
-  - Consumer protection
-  - Cosmetics
-  - Credit
-  - Customs duties and inspection
-  - Disaster assistance
-  - Domestic violence
-  - Drugs
-  - Electronic funds transfers
-  - Excise taxes
-  - Explosives
-  - Exports
-  - Food additives
-  - Foods
-  - Foreign trade zones
-  - Freedom of information
-  - Fruit juices
-  - Fruits
-  - Gasohol
-  - Government employees
-  - Hazardous substances
-  - Health
-  - Imports
-  - Intergovernmental relations
-  - Labeling
-  - Law enforcement
-  - Law enforcement officers
-  - Liquors
-  - Military personnel
-  - Packaging and containers
-  - Penalties
-  - Privacy
-  - Puerto Rico
-  - Reporting and recordkeeping requirements
-  - Research
-  - Safety
-  - Science and technology
-  - Scientific equipment
-  - Security measures
-  - Seizures and forfeitures
-  - Spices and flavorings
-  - Stills
-  - Surety bonds
-  - Tobacco
-  - Trade practices
-  - Transportation
-  - Vessels
-  - Vinegar
-  - Virgin Islands
-  - Warehouses
-  - Wine
+  - additives
+  - advertising
+  - aircraft
+  - alcohol
+  - alcoholic
+  - antitrust
+  - armed
+  - arms
+  - arson
+  - authority
+  - bankruptcy
+  - basin
+  - beer
+  - beverages
+  - caribbean
+  - chemicals
+  - cigarettes
+  - cigars
+  - consumer
+  - containers
+  - cosmetics
+  - customs
+  - delegations
+  - disaster
+  - domestic
+  - drugs
+  - duties
+  - electronic
+  - equipment
+  - excise
+  - explosives
+  - exports
+  - flavorings
+  - food
+  - foods
+  - forces
+  - forfeitures
+  - fruit
+  - fruits
+  - funds
+  - gasohol
+  - hazardous
+  - imports
+  - initiative
+  - inspection
+  - juices
+  - labeling
+  - liquors
+  - measures
+  - military
+  - munitions
+  - officers
+  - packaging
+  - personnel
+  - practices
+  - puerto
+  - rico
+  - science
+  - scientific
+  - seizures
+  - spices
+  - stills
+  - substances
+  - surety
+  - tobacco
+  - trade
+  - transfers
+  - vinegar
+  - violence
+  - virgin
+  - warehouses
+  - wine
+  - zones
   misc:
     Division Chief:
       name: Stephanie Boucher
@@ -920,30 +928,30 @@ departments:
   - dea.foia@usdoj.gov
   fax: 202-307-8556
   keywords:
-  - Administrative practice and procedure
-  - Arms and munitions
-  - Authority delegations (Government agencies)
-  - Chemicals
-  - Communications equipment
-  - Copyright
-  - Courts
-  - Crime
-  - Drug abuse
-  - Drug traffic control
-  - Exports
-  - Gambling
-  - Government employees
-  - Imports
-  - Motor vehicles
-  - Organization and functions (Government agencies)
-  - Prescription drugs
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Research
-  - Security measures
-  - Seizures and forfeitures
-  - Whistleblowing
-  - Wiretapping and electronic surveillance
+  - arms
+  - authority
+  - chemicals
+  - copyright
+  - courts
+  - crime
+  - delegations
+  - drug
+  - drugs
+  - electronic
+  - equipment
+  - exports
+  - forfeitures
+  - gambling
+  - imports
+  - measures
+  - munitions
+  - prescription
+  - seizures
+  - surveillance
+  - traffic
+  - vehicles
+  - whistleblowing
+  - wiretapping
   misc:
     Chief, Freedom of Information/Privacy Act Unit, FOI/Records Management Section:
       name: Katherine L. Myrick
@@ -1131,19 +1139,13 @@ departments:
   - EOIR.FOIARequests@usdoj.gov
   fax: 703-605-0570
   keywords:
-  - Administrative practice and procedure
-  - Aliens
-  - Citizenship and naturalization
-  - Civil rights
-  - Employment
-  - Equal employment opportunity
-  - Immigration
-  - Law enforcement
-  - Lawyers
-  - Legal services
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Reporting and recordkeeping requirements
+  - aliens
+  - citizenship
+  - immigration
+  - lawyers
+  - legal
+  - naturalization
+  - services
   misc:
     Senior Associate General Counsel, Office of the General Counsel:
       name: Cecelia Espenoza
@@ -1496,22 +1498,16 @@ departments:
   - foiparequest@ic.fbi.gov
   fax: 540-868-4997
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Classified information
-  - Computer technology
-  - Courts
-  - Crime
-  - Intergovernmental relations
-  - Investigations
-  - Law enforcement
-  - Law enforcement officers
-  - Penalties
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Security measures
-  - Telecommunications
-  - Wiretapping and electronic surveillance
+  - classified
+  - computer
+  - courts
+  - crime
+  - electronic
+  - measures
+  - officers
+  - surveillance
+  - telecommunications
+  - wiretapping
   misc:
     Chief, Record/Information Dissemination Section, Records Management Division:
       name: David M. Hardy
@@ -1628,12 +1624,10 @@ departments:
   emails:
   - ogc_efoia@bop.gov
   keywords:
-  - Administrative practice and procedure
-  - Claims
-  - Employment
-  - Lawyers
-  - Legal services
-  - Prisoners
+  - lawyers
+  - legal
+  - prisoners
+  - services
   misc:
     Chief, FOIA/PA Section:
       name: Wanda M. Hunt
@@ -2359,27 +2353,25 @@ departments:
   - FOIAOJP@usdoj.gov
   fax: 202-307-1419
   keywords:
-  - Administrative practice and procedure
-  - Claims
-  - Colleges and universities
-  - Crime
-  - Disability benefits
-  - Education
-  - Educational facilities
-  - Educational study programs
-  - Emergency medical services
-  - Firefighters
-  - Grant programs
-  - Grant programs-law
-  - Law enforcement
-  - Law enforcement officers
-  - Motor vehicle safety
-  - Motor vehicles
-  - Reporting and recordkeeping requirements
-  - Schools
-  - Student aid
-  - Transportation
-  - Victim compensation
+  - aid
+  - benefits
+  - colleges
+  - compensation
+  - crime
+  - disability
+  - emergency
+  - firefighters
+  - medical
+  - motor
+  - officers
+  - programs-law
+  - services
+  - student
+  - study
+  - universities
+  - vehicle
+  - vehicles
+  - victim
   misc:
     Government Information Specialist:
       name: Dorothy Lee
@@ -3507,9 +3499,9 @@ departments:
   emails:
   - USPC.FOIA@usdoj.gov
   keywords:
-  - Administrative practice and procedure
-  - Prisoners
-  - Probation and parole
+  - parole
+  - prisoners
+  - probation
   misc:
     FOIA/PA Specialist:
       name: Anissa Banks
@@ -3588,201 +3580,204 @@ emails:
 - MRUFOIA.Requests@usdoj.gov
 fax: 301-341-0772
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Air carriers
-- Aircraft
-- Airmen
-- Airports
-- Alcoholism
-- Aliens
-- American Samoa
-- Antitrust
-- Archives and records
-- Arms and munitions
-- Authority delegations (Government agencies)
-- Bankruptcy
-- Blind
-- Broadband
-- Brokers
-- Buildings and facilities
-- Business and industry
-- Cancer
-- Chemicals
-- Cigars and cigarettes
-- Citizenship and naturalization
-- Civil rights
-- Claims
-- Classified information
-- Clemency
-- Colleges and universities
-- Communications
-- Communications equipment
-- Community development
-- Computer technology
-- Consumer protection
-- Copyright
-- Courts
-- Credit
-- Crime
-- Cultural exchange programs
-- Customs duties and inspection
-- Disability benefits
-- Disaster assistance
-- Domestic violence
-- Drug abuse
-- Drug traffic control
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Elections
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Emergency medical services
-- Employment
-- Environmental impact statements
-- Environmental protection
-- Equal educational opportunity
-- Equal employment opportunity
-- Ethics
-- Excise taxes
-- Explosives
-- Exports
-- Federal buildings and facilities
-- Federally affected areas
-- Firefighters
-- Foreign officials
-- Foreign relations
-- Fraud
-- Freedom of information
-- Gambling
-- Government contracts
-- Government employees
-- Government property
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-law
-- Grant programs-social programs
-- Guam
-- Hazardous substances
-- Health care
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Historic preservation
-- Home improvement
-- Homeless
-- Hospitals
-- Human research subjects
-- Immigration
-- Imports
-- Income taxes
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Justice Department
-- Juvenile delinquency
-- Labor
-- Law enforcement
-- Law enforcement officers
-- Lawyers
-- Legal services
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Maritime carriers
-- Mass transportation
-- Migrant labor
-- Military personnel
-- Mortgage insurance
-- Mortgages
-- Motor vehicle safety
-- Motor vehicles
-- Nonprofit organizations
-- Northern Mariana Islands
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Packaging and containers
-- Passports and visas
-- Penalties
-- Political committees and parties
-- Prescription drugs
-- Prisoners
-- Prisons
-- Privacy
-- Private schools
-- Probation and parole
-- Radioactive materials
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Scientific equipment
-- Seals and insignia
-- Search warrants
-- Securities
-- Security measures
-- Seizures and forfeitures
-- Sex discrimination
-- Small businesses
-- State and local governments
-- Student aid
-- Students
-- Sunshine Act
-- Surety bonds
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Terrorism
-- Tobacco
-- Transportation
-- Treaties
-- Trusts and trustees
-- Underground mining
-- Uranium
-- Urban areas
-- Vessels
-- Veterans
-- Victim compensation
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Warehouses
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Whistleblowing
-- Wiretapping and electronic surveillance
-- Women
+- act
+- adult
+- affected
+- aid
+- aircraft
+- airmen
+- airports
+- alcoholism
+- aliens
+- american
+- antitrust
+- archives
+- arms
+- authority
+- bankruptcy
+- benefits
+- blind
+- broadband
+- brokers
+- businesses
+- cancer
+- care
+- carriers
+- chemicals
+- cigarettes
+- cigars
+- citizenship
+- classified
+- clemency
+- colleges
+- committees
+- communications
+- compensation
+- computer
+- construction
+- consumer
+- containers
+- copyright
+- courts
+- crime
+- cultural
+- customs
+- delegations
+- delinquency
+- department
+- disability
+- disadvantaged
+- disaster
+- disposal
+- domestic
+- drug
+- drugs
+- duties
+- elections
+- electronic
+- elementary
+- emergency
+- equipment
+- ethics
+- exchange
+- excise
+- explosives
+- exports
+- federally
+- fellowships
+- firefighters
+- forfeitures
+- fraud
+- gambling
+- governments
+- guam
+- hazardous
+- highways
+- historic
+- home
+- homeless
+- hospitals
+- human
+- immigration
+- impact
+- imports
+- improvement
+- indians-education
+- insignia
+- inspection
+- international
+- inventions
+- justice
+- juvenile
+- lawyers
+- legal
+- local
+- manpower
+- mariana
+- maritime
+- mass
+- materials
+- measures
+- medical
+- migrant
+- military
+- mining
+- mortgage
+- mortgages
+- motor
+- munitions
+- naturalization
+- nonprofit
+- northern
+- officers
+- officials
+- pacific
+- packaging
+- parole
+- parties
+- passports
+- patents
+- personnel
+- political
+- prescription
+- preservation
+- prisoners
+- prisons
+- private
+- probation
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-law
+- programs-social
+- radioactive
+- railroads
+- rates
+- rehabilitation
+- religious
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- scientific
+- seals
+- search
+- secondary
+- seizures
+- services
+- sex
+- small
+- state
+- statements
+- student
+- students
+- study
+- subjects
+- substances
+- sunshine
+- supply
+- surety
+- surveillance
+- taxes
+- teachers
+- technical
+- technology
+- telecommunications
+- telephone
+- territory
+- terrorism
+- tobacco
+- traffic
+- training
+- treaties
+- treatment
+- trust
+- trustees
+- trusts
+- underground
+- universities
+- uranium
+- urban
+- utilities
+- vehicle
+- vehicles
+- veterans
+- victim
+- violence
+- virgin
+- visas
+- vocational
+- warehouses
+- warrants
+- waste
+- watersheds
+- whistleblowing
+- wiretapping
+- women
 name: Department of Justice
 phone: 301-583-7354
 public_liaison:

--- a/contacts/data/DOT.yaml
+++ b/contacts/data/DOT.yaml
@@ -207,86 +207,79 @@ departments:
   - 7-AWA-ARC-FOIA@faa.gov
   fax: 202-493-5032
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Afghanistan
-  - Agriculture
-  - Air carriers
-  - Air pollution control
-  - Air taxis
-  - Air traffic control
-  - Air traffic controllers
-  - Air transportation
-  - Aircraft
-  - Airmen
-  - Airports
-  - Airspace
-  - Alaska
-  - Alcohol abuse
-  - Alcoholism
-  - Armed forces
-  - Arms and munitions
-  - Authority delegations (Government agencies)
-  - Aviation safety
-  - Canada
-  - Charter flights
-  - Claims
-  - Common carriers
-  - Confidential business information
-  - Consumer protection
-  - Cuba
-  - Drug abuse
-  - Drug testing
-  - Educational facilities
-  - Environmental protection
-  - Equal access to justice
-  - Ethiopia
-  - Explosives
-  - Exports
-  - Federal Aviation Administration
-  - Federal buildings and facilities
-  - Flammable materials
-  - Fraud
-  - Freight
-  - Freight forwarders
-  - Government contracts
-  - Government property
-  - Hazardous materials transportation
-  - Health
-  - Health professions
-  - Highway safety
-  - Imports
-  - Indemnity payments
-  - Insurance
-  - Investigations
-  - Iraq
-  - Law enforcement
-  - Law enforcement officers
-  - Lawyers
-  - Libya
-  - Mexico
-  - Motor carriers
-  - National defense
-  - National parks
-  - Navigation (air)
-  - Noise control
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Political candidates
-  - Puerto Rico
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Schools
-  - Security measures
-  - Signs and symbols
-  - Smoking
-  - Space transportation and exploration
-  - Students
-  - Teachers
-  - Transportation
-  - Weather
-  - X-rays
-  - Yugoslavia
+  - abuse
+  - access
+  - administration
+  - afghanistan
+  - air
+  - aircraft
+  - airmen
+  - airports
+  - airspace
+  - alaska
+  - alcohol
+  - alcoholism
+  - armed
+  - arms
+  - authority
+  - aviation
+  - canada
+  - candidates
+  - carriers
+  - charter
+  - common
+  - confidential
+  - consumer
+  - control
+  - controllers
+  - cuba
+  - defense
+  - delegations
+  - drug
+  - ethiopia
+  - exploration
+  - explosives
+  - exports
+  - federal
+  - flammable
+  - flights
+  - forces
+  - forwarders
+  - fraud
+  - freight
+  - hazardous
+  - highway
+  - imports
+  - indemnity
+  - iraq
+  - justice
+  - lawyers
+  - libya
+  - materials
+  - measures
+  - mexico
+  - munitions
+  - national
+  - navigation
+  - noise
+  - officers
+  - parks
+  - payments
+  - political
+  - puerto
+  - rico
+  - signs
+  - smoking
+  - space
+  - students
+  - symbols
+  - taxis
+  - teachers
+  - testing
+  - traffic
+  - weather
+  - x-rays
+  - yugoslavia
   misc:
     FOIA Coordinator:
       phone:
@@ -403,56 +396,54 @@ departments:
   - foia.officer@fhwa.dot.gov
   fax: 202-366-1380
   keywords:
-  - Accounting
-  - Alcohol and alcoholic beverages
-  - Bonds
-  - Bridges
-  - Civil rights
-  - Claims
-  - Communications
-  - Communications equipment
-  - Electronic products
-  - Energy conservation
-  - Environmental impact statements
-  - Environmental protection
-  - Flood plains
-  - Government contracts
-  - Government procurement
-  - Grant programs
-  - Grant programs-transportation
-  - Highway safety
-  - Highways and roads
-  - Historic preservation
-  - Indians-lands
-  - Insurance
-  - Intergovernmental relations
-  - Intermodal transportation
-  - Investments
-  - Mass transportation
-  - Motor carriers
-  - Motor vehicles
-  - National forests
-  - National parks
-  - Noise control
-  - Public lands
-  - Radio
-  - Railroad safety
-  - Railroads
-  - Real property acquisition
-  - Relocation assistance
-  - Reporting and recordkeeping requirements
-  - Research
-  - Rights-of-way
-  - Safety
-  - Signs and symbols
-  - Soil conservation
-  - Taxes
-  - Traffic regulations
-  - Transportation
-  - Travel
-  - Travel restrictions
-  - Utilities
-  - Wildlife refuges
+  - acquisition
+  - alcohol
+  - alcoholic
+  - beverages
+  - bridges
+  - communications
+  - conservation
+  - electronic
+  - energy
+  - equipment
+  - flood
+  - forests
+  - highway
+  - highways
+  - historic
+  - impact
+  - indians-lands
+  - intermodal
+  - investments
+  - lands
+  - mass
+  - motor
+  - national
+  - noise
+  - parks
+  - plains
+  - preservation
+  - procurement
+  - programs-transportation
+  - radio
+  - railroad
+  - railroads
+  - real
+  - refuges
+  - regulations
+  - relocation
+  - restrictions
+  - rights-of-way
+  - roads
+  - signs
+  - soil
+  - statements
+  - symbols
+  - traffic
+  - travel
+  - utilities
+  - vehicles
+  - wildlife
   misc:
     FOIA/PA Contact:
       name: Manizheh Boehm
@@ -569,42 +560,35 @@ departments:
   - frafoia@dot.gov
   fax: 202-493-6068
   keywords:
-  - Administrative practice and procedure
-  - Alcohol abuse
-  - Bridges
-  - Buildings and facilities
-  - Civil rights
-  - Communications
-  - Drug abuse
-  - Drug testing
-  - Environmental protection
-  - Fire prevention
-  - Freight
-  - Glass and glass products
-  - Grant programs-transportation
-  - Hazardous materials transportation
-  - Highway safety
-  - Highways and roads
-  - Investigations
-  - Investments
-  - Loan programs-transportation
-  - Motor carriers
-  - National Transportation Safety Board
-  - Noise control
-  - Occupational safety and health
-  - Penalties
-  - Radio
-  - Railroad employees
-  - Railroad safety
-  - Railroads
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Security measures
-  - Sex discrimination
-  - State and local governments
-  - Telephone
-  - Transportation
-  - Whistleblowing
+  - abuse
+  - alcohol
+  - board
+  - bridges
+  - drug
+  - fire
+  - freight
+  - glass
+  - governments
+  - hazardous
+  - highway
+  - highways
+  - investments
+  - local
+  - materials
+  - measures
+  - noise
+  - occupational
+  - prevention
+  - programs-transportation
+  - radio
+  - railroad
+  - railroads
+  - roads
+  - sex
+  - state
+  - telephone
+  - testing
+  - whistleblowing
   misc:
     FOIA/PA Contact, Office of the Chief Counsel:
       name: Denise Kollehlon
@@ -681,36 +665,33 @@ departments:
   - FTA.FOIA@dot.gov
   fax: 202-366-7164
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Alcohol abuse
-  - Buses
-  - Disaster assistance
-  - Drug abuse
-  - Drug testing
-  - Energy conservation
-  - Environmental impact statements
-  - Environmental protection
-  - Freedom of information
-  - Government contracts
-  - Grant programs
-  - Grant programs-transportation
-  - Highway safety
-  - Highways and roads
-  - Historic preservation
-  - Investments
-  - Mass transportation
-  - Motor carriers
-  - Motor vehicle safety
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Public lands
-  - Railroads
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Transportation
-  - Uniform System of Accounts
-  - Wildlife refuges
+  - abuse
+  - accounts
+  - alcohol
+  - buses
+  - conservation
+  - disaster
+  - drug
+  - energy
+  - highway
+  - highways
+  - historic
+  - impact
+  - investments
+  - lands
+  - mass
+  - motor
+  - preservation
+  - programs-transportation
+  - railroads
+  - refuges
+  - roads
+  - statements
+  - system
+  - testing
+  - uniform
+  - vehicle
+  - wildlife
   misc:
     FOIA/PA Contact:
       name: Nancy Sipes
@@ -792,51 +773,44 @@ departments:
   - foia@fmcsa.dot.gov
   fax: 202-385-2335
   keywords:
-  - Administrative practice and procedure
-  - Advertising
-  - Aged
-  - Agricultural commodities
-  - Alcohol abuse
-  - Blind
-  - Brokers
-  - Buses
-  - Civil rights
-  - Claims
-  - Consumer protection
-  - Cooperatives
-  - Credit
-  - Drug abuse
-  - Drug testing
-  - Freight
-  - Freight forwarders
-  - Grant programs
-  - Grant programs-transportation
-  - Hazardous materials transportation
-  - Highway safety
-  - Highways and roads
-  - Individuals with disabilities
-  - Insurance
-  - Intergovernmental relations
-  - Intermodal transportation
-  - Investigations
-  - Maritime carriers
-  - Mexico
-  - Migrant labor
-  - Motor carriers
-  - Motor vehicle safety
-  - Moving of household goods
-  - Noise control
-  - Occupational safety and health
-  - Parking
-  - Penalties
-  - Radioactive materials
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Seafood
-  - Smoking
-  - Surety bonds
-  - Tires
-  - Transportation
+  - abuse
+  - advertising
+  - agricultural
+  - alcohol
+  - blind
+  - brokers
+  - buses
+  - carriers
+  - commodities
+  - consumer
+  - cooperatives
+  - drug
+  - forwarders
+  - freight
+  - goods
+  - hazardous
+  - highway
+  - highways
+  - household
+  - intermodal
+  - maritime
+  - materials
+  - mexico
+  - migrant
+  - motor
+  - moving
+  - noise
+  - occupational
+  - parking
+  - programs-transportation
+  - radioactive
+  - roads
+  - seafood
+  - smoking
+  - surety
+  - testing
+  - tires
+  - vehicle
   misc:
     FOIA/PA Contact (MC-MMI):
       name: Tiffanie C. Coleman
@@ -958,41 +932,32 @@ departments:
   - mary.sprague@dot.gov
   fax: 202-366-3820
   keywords:
-  - Administrative practice and procedure
-  - Air pollution control
-  - Alcohol abuse
-  - Alcohol and alcoholic beverages
-  - Authority delegations (Government agencies)
-  - Confidential business information
-  - Consumer protection
-  - Crime
-  - Drug abuse
-  - Electric power
-  - Energy conservation
-  - Environmental protection
-  - Freedom of information
-  - Fuel economy
-  - Gasoline
-  - Grant programs
-  - Grant programs-transportation
-  - Highway safety
-  - Imports
-  - Insurance
-  - Insurance companies
-  - Intergovernmental relations
-  - Labeling
-  - Motor vehicle pollution
-  - Motor vehicle safety
-  - Motor vehicles
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Reporting and recordkeeping requirements
-  - Research
-  - Rubber and rubber products
-  - Telecommunications
-  - Tires
-  - Transportation
-  - Vessels
+  - abuse
+  - alcohol
+  - alcoholic
+  - authority
+  - beverages
+  - companies
+  - confidential
+  - conservation
+  - consumer
+  - crime
+  - delegations
+  - economy
+  - energy
+  - fuel
+  - gasoline
+  - highway
+  - imports
+  - labeling
+  - motor
+  - pollution
+  - programs-transportation
+  - rubber
+  - telecommunications
+  - tires
+  - vehicle
+  - vehicles
   misc:
     NHTSA Executive Secretariat:
       name: FOIA Contact
@@ -1092,51 +1057,47 @@ departments:
     phone:
     - 202-366-5320
   keywords:
-  - Administrative practice and procedure
-  - Antitrust
-  - Authority delegations (Government agencies)
-  - Citizenship and naturalization
-  - Claims
-  - Classified information
-  - Common carriers
-  - Courts
-  - Disability benefits
-  - Equal access to justice
-  - Exports
-  - Fishing vessels
-  - Freedom of information
-  - Freight
-  - Freight forwarders
-  - Government contracts
-  - Government employees
-  - Grant programs-education
-  - Grant programs-transportation
-  - Highways and roads
-  - Income taxes
-  - Insurance
-  - Intermodal transportation
-  - Investigations
-  - Investments
-  - Lawyers
-  - Loan programs-transportation
-  - Maritime carriers
-  - Mortgages
-  - National defense
-  - Organization and functions (Government agencies)
-  - Passenger vessels
-  - Penalties
-  - Privacy
-  - Railroads
-  - Reporting and recordkeeping requirements
-  - Schools
-  - Seals and insignia
-  - Seamen
-  - Sunshine Act
-  - Surety bonds
-  - Transportation
-  - Trusts and trustees
-  - Uniform System of Accounts
-  - Vessels
+  - access
+  - accounts
+  - act
+  - antitrust
+  - authority
+  - benefits
+  - carriers
+  - citizenship
+  - classified
+  - common
+  - courts
+  - defense
+  - delegations
+  - disability
+  - exports
+  - fishing
+  - forwarders
+  - freight
+  - highways
+  - insignia
+  - intermodal
+  - investments
+  - justice
+  - lawyers
+  - maritime
+  - mortgages
+  - naturalization
+  - passenger
+  - programs-education
+  - programs-transportation
+  - railroads
+  - roads
+  - seals
+  - seamen
+  - sunshine
+  - surety
+  - system
+  - trustees
+  - trusts
+  - uniform
+  - vessels
   name: Maritime Administration
   phone: 202-366-5320
   public_liaison:
@@ -1226,49 +1187,46 @@ departments:
     phone:
     - 202-366-6119
   keywords:
-  - Administrative practice and procedure
-  - Air carriers
-  - Alcohol abuse
-  - Authority delegations (Government agencies)
-  - Carbon dioxide
-  - Disaster assistance
-  - Drug abuse
-  - Drug testing
-  - Education
-  - Environmental protection
-  - Exports
-  - Fire prevention
-  - Grant programs
-  - Grant programs-Indians
-  - Grant programs-environmental protection
-  - Grant programs-transportation
-  - Hazardous materials transportation
-  - Hazardous substances
-  - Hazardous waste
-  - Highway safety
-  - Imports
-  - Indians
-  - Intermodal transportation
-  - Labeling
-  - Maritime carriers
-  - Motor carriers
-  - Motor vehicle safety
-  - Natural gas
-  - Oil pollution
-  - Organization and functions (Government agencies)
-  - Packaging and containers
-  - Penalties
-  - Petroleum
-  - Pipeline safety
-  - Pipelines
-  - Radioactive materials
-  - Railroad safety
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Security measures
-  - Transportation
-  - Uranium
-  - Water pollution control
+  - abuse
+  - alcohol
+  - authority
+  - carbon
+  - carriers
+  - containers
+  - delegations
+  - dioxide
+  - disaster
+  - drug
+  - exports
+  - fire
+  - gas
+  - hazardous
+  - highway
+  - imports
+  - intermodal
+  - labeling
+  - maritime
+  - materials
+  - measures
+  - motor
+  - natural
+  - oil
+  - packaging
+  - petroleum
+  - pipeline
+  - pipelines
+  - pollution
+  - prevention
+  - programs-environmental
+  - programs-indians
+  - programs-transportation
+  - radioactive
+  - railroad
+  - substances
+  - testing
+  - uranium
+  - vehicle
+  - waste
   name: Pipeline and Hazardous Materials Safety Administration
   phone: 202-366-6119
   public_liaison:
@@ -1378,13 +1336,11 @@ departments:
   - slsdc@dot.gov
   fax: 315-764-3235
   keywords:
-  - Hazardous materials transportation
-  - Navigation (water)
-  - Penalties
-  - Radio
-  - Reporting and recordkeeping requirements
-  - Vessels
-  - Waterways
+  - hazardous
+  - materials
+  - navigation
+  - radio
+  - waterways
   misc:
     FOIA/PA Contact:
       name: Carrie Lavigne
@@ -1461,28 +1417,27 @@ departments:
   - FOIA.Privacy@stb.dot.gov
   fax: 202-245-0460
   keywords:
-  - Administrative practice and procedure
-  - Agricultural commodities
-  - Antitrust
-  - Authority delegations (Government agencies)
-  - Bankruptcy
-  - Brokers
-  - Common carriers
-  - Communications
-  - Confidential business information
-  - Environmental impact statements
-  - Freedom of information
-  - Freight
-  - Freight forwarders
-  - Intermodal transportation
-  - Investigations
-  - Maritime carriers
-  - Motor carriers
-  - Organization and functions (Government agencies)
-  - Railroads
-  - Reporting and recordkeeping requirements
-  - Statistics
-  - Uniform System of Accounts
+  - accounts
+  - agricultural
+  - antitrust
+  - authority
+  - bankruptcy
+  - brokers
+  - carriers
+  - commodities
+  - common
+  - confidential
+  - delegations
+  - forwarders
+  - freight
+  - impact
+  - intermodal
+  - maritime
+  - railroads
+  - statements
+  - statistics
+  - system
+  - uniform
   misc:
     FOIA/Privacy Act Officer:
       name: Marilyn R. Levitt
@@ -1556,302 +1511,308 @@ emails:
 - ost.foia@dot.gov
 fax: 202-366-8536
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Advertising
-- Advisory committees
-- Afghanistan
-- Aged
-- Agricultural commodities
-- Agriculture
-- Air carriers
-- Air pollution control
-- Air rates and fares
-- Air taxis
-- Air traffic control
-- Air traffic controllers
-- Air transportation
-- Aircraft
-- Airmen
-- Airports
-- Airspace
-- Alaska
-- Alcohol abuse
-- Alcohol and alcoholic beverages
-- Alcoholism
-- American Samoa
-- Anchorage grounds
-- Antitrust
-- Archives and records
-- Armed forces
-- Arms and munitions
-- Authority delegations (Government agencies)
-- Aviation safety
-- Bankruptcy
-- Blind
-- Bonds
-- Bridges
-- Broadband
-- Brokers
-- Buildings and facilities
-- Buses
-- Business and industry
-- Canada
-- Carbon dioxide
-- Cargo vessels
-- Charter flights
-- Citizenship and naturalization
-- Civil rights
-- Claims
-- Code of Federal Regulations
-- Colleges and universities
-- Common carriers
-- Communications
-- Communications equipment
-- Community development
-- Concessions
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Continental shelf
-- Cooperatives
-- Copyright
-- Credit
-- Crime
-- Cuba
-- Cultural exchange programs
-- Defense Department
-- Disability benefits
-- Disaster assistance
-- Drug abuse
-- Drug testing
-- Drugs
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Electronic products
-- Elementary and secondary education
-- Employment
-- Endangered and threatened species
-- Energy conservation
-- Environmental impact statements
-- Environmental protection
-- Equal access to justice
-- Equal educational opportunity
-- Equal employment opportunity
-- Ethics
-- Ethiopia
-- Explosives
-- Exports
-- Federal Aviation Administration
-- Federal buildings and facilities
-- Federally affected areas
-- Fire prevention
-- Fishing vessels
-- Flammable materials
-- Flood plains
-- Foreign relations
-- Fraud
-- Freedom of information
-- Freight
-- Freight forwarders
-- Fuel economy
-- Gases
-- Gasoline
-- Glass and glass products
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Government publications
-- Grant programs
-- Grant programs-Indians
-- Grant programs-education
-- Grant programs-environmental protection
-- Grant programs-health
-- Grant programs-social programs
-- Grant programs-transportation
-- Grant programs-veterans
-- Great Lakes
-- Guam
-- Harbors
-- Hazardous materials transportation
-- Hazardous substances
-- Hazardous waste
-- Health
-- Health care
-- Health facilities
-- Health insurance
-- Health professions
-- Highway safety
-- Highways and roads
-- Historic preservation
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Imports
-- Income taxes
-- Indemnity payments
-- Indians
-- Indians-education
-- Indians-lands
-- Individuals with disabilities
-- Insurance
-- Insurance companies
-- Intergovernmental relations
-- Intermodal transportation
-- International organizations
-- Inventions and patents
-- Investigations
-- Investments
-- Iraq
-- Kuwait
-- Labeling
-- Laboratories
-- Law enforcement
-- Law enforcement officers
-- Lawyers
-- Lebanon
-- Libya
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-education
-- Loan programs-energy
-- Loan programs-housing and community development
-- Loan programs-transportation
-- Loan programs-veterans
-- Manpower training programs
-- Manufactured homes
-- Marine mammals
-- Marine safety
-- Maritime carriers
-- Mass transportation
-- Mexico
-- Migrant labor
-- Military personnel
-- Minority businesses
-- Mortgage insurance
-- Mortgages
-- Motor carriers
-- Motor vehicle pollution
-- Motor vehicle safety
-- Motor vehicles
-- Moving of household goods
-- National Transportation Safety Board
-- National defense
-- National forests
-- National parks
-- Natural gas
-- Navigation (air)
-- Navigation (water)
-- Noise control
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nuclear vessels
-- Occupational safety and health
-- Oceanographic research vessels
-- Oil and gas exploration
-- Oil pollution
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Packaging and containers
-- Parking
-- Passenger vessels
-- Penalties
-- Petroleum
-- Pipeline safety
-- Pipelines
-- Political candidates
-- Privacy
-- Private schools
-- Public lands
-- Puerto Rico
-- Radiation protection
-- Radio
-- Radioactive materials
-- Railroad employees
-- Railroad safety
-- Railroads
-- Real property acquisition
-- Religious discrimination
-- Relocation assistance
-- Reporting and recordkeeping requirements
-- Research
-- Rights-of-way
-- Rubber and rubber products
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seafood
-- Seamen
-- Securities
-- Security measures
-- Sewage disposal
-- Sex discrimination
-- Signs and symbols
-- Small businesses
-- Smoking
-- Soil conservation
-- Space transportation and exploration
-- State and local governments
-- Statistics
-- Strategic and critical materials
-- Student aid
-- Students
-- Surety bonds
-- Taxes
-- Teachers
-- Telecommunications
-- Telephone
-- Terrorism
-- Time
-- Tires
-- Traffic regulations
-- Transportation
-- Transportation Department
-- Travel
-- Travel and transportation expenses
-- Travel restrictions
-- Treaties
-- Trusts and trustees
-- Truth in lending
-- Uniform System of Accounts
-- Uranium
-- Urban areas
-- Utilities
-- Vessels
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Volunteers
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Waterways
-- Weather
-- Whistleblowing
-- Wildlife refuges
-- Women
-- X-rays
-- Yugoslavia
+- abuse
+- access
+- accounts
+- acquisition
+- administration
+- adult
+- advertising
+- advisory
+- affected
+- afghanistan
+- agricultural
+- aid
+- air
+- aircraft
+- airmen
+- airports
+- airspace
+- alaska
+- alcohol
+- alcoholic
+- alcoholism
+- american
+- anchorage
+- antitrust
+- archives
+- armed
+- arms
+- authority
+- aviation
+- bankruptcy
+- benefits
+- beverages
+- blind
+- board
+- bonds
+- bridges
+- broadband
+- brokers
+- buses
+- businesses
+- canada
+- candidates
+- carbon
+- care
+- cargo
+- carriers
+- charter
+- citizenship
+- code
+- colleges
+- committees
+- commodities
+- common
+- communications
+- companies
+- concessions
+- confidential
+- conservation
+- construction
+- consumer
+- containers
+- continental
+- control
+- controllers
+- cooperatives
+- copyright
+- crime
+- critical
+- cuba
+- cultural
+- defense
+- delegations
+- department
+- dioxide
+- disability
+- disadvantaged
+- disaster
+- disposal
+- drug
+- drugs
+- economy
+- electronic
+- elementary
+- endangered
+- energy
+- equipment
+- ethics
+- ethiopia
+- exchange
+- expenses
+- exploration
+- explosives
+- exports
+- fares
+- federal
+- federally
+- fellowships
+- fire
+- fishing
+- flammable
+- flights
+- flood
+- forces
+- forests
+- forwarders
+- fraud
+- freight
+- fuel
+- gas
+- gases
+- gasoline
+- glass
+- goods
+- governments
+- great
+- grounds
+- guam
+- harbors
+- hazardous
+- highway
+- highways
+- historic
+- home
+- homeless
+- homes
+- hospitals
+- hostages
+- household
+- human
+- impact
+- imports
+- improvement
+- indemnity
+- indians-education
+- indians-lands
+- intermodal
+- international
+- inventions
+- investments
+- iraq
+- justice
+- kuwait
+- labeling
+- laboratories
+- lakes
+- lands
+- lawyers
+- lebanon
+- lending
+- libya
+- local
+- mammals
+- manpower
+- manufactured
+- mariana
+- marine
+- maritime
+- mass
+- materials
+- measures
+- mexico
+- migrant
+- military
+- minority
+- mortgage
+- mortgages
+- motor
+- moving
+- munitions
+- national
+- natural
+- naturalization
+- navigation
+- noise
+- nonprofit
+- northern
+- nuclear
+- occupational
+- oceanographic
+- officers
+- oil
+- pacific
+- packaging
+- parking
+- parks
+- passenger
+- patents
+- payments
+- personnel
+- petroleum
+- pipeline
+- pipelines
+- plains
+- political
+- pollution
+- preservation
+- prevention
+- private
+- procurement
+- products
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-environmental
+- programs-indians
+- programs-social
+- programs-transportation
+- programs-veterans
+- property
+- protection
+- publications
+- puerto
+- radiation
+- radio
+- radioactive
+- railroad
+- railroads
+- rates
+- real
+- refuges
+- regulations
+- rehabilitation
+- religious
+- relocation
+- restrictions
+- rico
+- rights-of-way
+- roads
+- rubber
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seafood
+- seamen
+- secondary
+- sewage
+- sex
+- shelf
+- signs
+- small
+- smoking
+- soil
+- space
+- species
+- state
+- statements
+- statistics
+- strategic
+- student
+- students
+- study
+- subjects
+- substances
+- supply
+- surety
+- symbols
+- system
+- taxes
+- taxis
+- teachers
+- telecommunications
+- telephone
+- territory
+- terrorism
+- testing
+- threatened
+- time
+- tires
+- traffic
+- training
+- travel
+- treaties
+- treatment
+- trust
+- trustees
+- trusts
+- truth
+- uniform
+- universities
+- uranium
+- urban
+- utilities
+- vehicle
+- vehicles
+- vessels
+- veterans
+- virgin
+- vocational
+- volunteers
+- waste
+- watersheds
+- waterways
+- weather
+- whistleblowing
+- wildlife
+- women
+- x-rays
+- yugoslavia
 name: Department of Transportation
 phone: 202-366-4542
 public_liaison:

--- a/contacts/data/DoD.yaml
+++ b/contacts/data/DoD.yaml
@@ -130,36 +130,30 @@ departments:
   emails: []
   fax: 703-696-7273
   keywords:
-  - Administrative practice and procedure
-  - Air carriers
-  - Alimony
-  - Archives and records
-  - Aviation safety
-  - Child support
-  - Civil defense
-  - Civil disorders
-  - Claims
-  - Courts
-  - Credit
-  - Disaster assistance
-  - Environmental impact statements
-  - Environmental protection
-  - Federal buildings and facilities
-  - Foreign relations
-  - Government employees
-  - Inventions and patents
-  - Law enforcement
-  - Military air transportation
-  - Military law
-  - Military personnel
-  - Motion pictures
-  - Motor vehicles
-  - Penalties
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Safety
-  - State and local governments
-  - Wake Island
+  - air
+  - alimony
+  - archives
+  - aviation
+  - child
+  - courts
+  - defense
+  - disaster
+  - disorders
+  - governments
+  - impact
+  - inventions
+  - island
+  - local
+  - military
+  - motion
+  - patents
+  - personnel
+  - pictures
+  - state
+  - statements
+  - support
+  - vehicles
+  - wake
   misc:
     FOIA Contact:
       name: JoAnne Collins
@@ -273,51 +267,41 @@ departments:
   - usarmy.belvoir.hqda-oaa-aha.mbx.rmda-foia@mail.mil
   fax: 703-428-6522
   keywords:
-  - Administrative practice and procedure
-  - Air pollution control
-  - Archives and records
-  - Armed forces
-  - Biologics
-  - Cemeteries
-  - Civil disorders
-  - Claims
-  - Credit
-  - Crime
-  - Disaster assistance
-  - District of Columbia
-  - Environmental impact statements
-  - Environmental protection
-  - Federal buildings and facilities
-  - Freedom of information
-  - Government contracts
-  - Government employees
-  - Government procurement
-  - Government property
-  - Hazardous substances
-  - Health
-  - Health care
-  - Historic preservation
-  - Intergovernmental relations
-  - Investigations
-  - Law
-  - Law enforcement
-  - Law enforcement officers
-  - Military law
-  - Military personnel
-  - National defense
-  - Natural resources
-  - Noise control
-  - Occupational safety and health
-  - Penalties
-  - Privacy
-  - Radiation protection
-  - Reporting and recordkeeping requirements
-  - Research
-  - Safety
-  - Traffic regulations
-  - Veterans
-  - Waste treatment and disposal
-  - Water pollution control
+  - archives
+  - armed
+  - biologics
+  - care
+  - cemeteries
+  - columbia
+  - control
+  - crime
+  - defense
+  - disaster
+  - disorders
+  - disposal
+  - district
+  - forces
+  - hazardous
+  - historic
+  - impact
+  - law
+  - military
+  - natural
+  - noise
+  - occupational
+  - officers
+  - personnel
+  - pollution
+  - preservation
+  - procurement
+  - radiation
+  - regulations
+  - statements
+  - substances
+  - traffic
+  - treatment
+  - veterans
+  - waste
   misc:
     FOIA Contact:
       name: Alecia Bolling
@@ -417,48 +401,41 @@ departments:
   description: The Navy's primary mission is to defend the United States.
   fax: 202-685-6580
   keywords:
-  - Administrative practice and procedure
-  - Aircraft
-  - Alimony
-  - Archives and records
-  - Armed forces
-  - Child support
-  - Claims
-  - Conflict of interests
-  - Courts
-  - Crime
-  - Educational research
-  - Endangered and threatened species
-  - Environmental impact statements
-  - Federal buildings and facilities
-  - Fish
-  - Freedom of information
-  - Government employees
-  - Government property
-  - Government property management
-  - Health care
-  - Historic preservation
-  - Housing
-  - Law
-  - Law enforcement
-  - Lawyers
-  - Legal services
-  - Marine safety
-  - Military law
-  - Military personnel
-  - National defense
-  - Navigation (water)
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Privacy
-  - Reporting and recordkeeping requirements
-  - Research
-  - Seals and insignia
-  - Security measures
-  - Surplus Government property
-  - Trusts and trustees
-  - Vessels
-  - Wildlife
+  - aircraft
+  - alimony
+  - archives
+  - armed
+  - care
+  - child
+  - courts
+  - crime
+  - defense
+  - endangered
+  - fish
+  - forces
+  - historic
+  - impact
+  - insignia
+  - law
+  - lawyers
+  - legal
+  - marine
+  - measures
+  - military
+  - navigation
+  - personnel
+  - preservation
+  - property
+  - seals
+  - services
+  - species
+  - statements
+  - support
+  - surplus
+  - threatened
+  - trustees
+  - trusts
+  - wildlife
   misc:
     FOIA Contact, Chief of Naval Operations:
       name: Robin Patterson
@@ -780,8 +757,7 @@ departments:
   emails:
   - DCAA-FOIA@dcaa.mil
   fax: 703-767-1011
-  keywords:
-  - Privacy
+  keywords: []
   name: Defense Contract Audit Agency - Headquarters
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1238,8 +1214,7 @@ departments:
   - hq-foia@dla.mil
   fax: 703-767-6091
   keywords:
-  - Government procurement
-  - Privacy
+  - procurement
   misc:
     'FOIA Contact, ATTN: DGA':
       name: Debbie Teer
@@ -3235,230 +3210,219 @@ departments:
 description: The Department of Defense provides the military forces needed to deter
   war, and to protect the security of the United States.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Advertising
-- Advisory committees
-- Aged
-- Agriculture
-- Air carriers
-- Air pollution control
-- Air traffic control
-- Aircraft
-- Airports
-- Alcohol abuse
-- Alcohol and alcoholic beverages
-- Alcoholism
-- Alimony
-- American Samoa
-- Archives and records
-- Armed forces
-- Armed forces reserves
-- Arms and munitions
-- Aviation safety
-- Biologics
-- Blind
-- Bridges
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Cemeteries
-- Child support
-- Child welfare
-- Civil defense
-- Civil disorders
-- Civil rights
-- Claims
-- Classified information
-- Coastal zone
-- Colleges and universities
-- Communications
-- Community development
-- Concessions
-- Conflict of interests
-- Conscientious objectors
-- Consumer protection
-- Continental shelf
-- Copyright
-- Courts
-- Credit
-- Credit unions
-- Crime
-- Cultural exchange programs
-- Dams
-- Day care
-- Defense Department
-- Defense communications
-- Dental health
-- Disability benefits
-- Disaster assistance
-- District of Columbia
-- Drug abuse
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Elections
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Endangered and threatened species
-- Energy
-- Environmental impact statements
-- Environmental protection
-- Equal educational opportunity
-- Equal employment opportunity
-- Federal buildings and facilities
-- Federally affected areas
-- Fire prevention
-- Fish
-- Flood control
-- Food assistance programs
-- Foreign currencies
-- Foreign relations
-- Fraud
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Government publications
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-housing and community development
-- Grant programs-social programs
-- Grant programs-veterans
-- Guam
-- HIV/AIDS
-- Hazardous substances
-- Health
-- Health care
-- Health facilities
-- Health insurance
-- Health professions
-- Health records
-- Highway safety
-- Historic preservation
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Housing
-- Human research subjects
-- Income taxes
-- Indians
-- Indians-education
-- Indians-lands
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Labor management relations
-- Labor unions
-- Law
-- Law enforcement
-- Law enforcement officers
-- Lawyers
-- Lebanon
-- Legal services
-- Life insurance
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-education
-- Loan programs-energy
-- Loan programs-housing and community development
-- Loan programs-veterans
-- Manpower training programs
-- Marine safety
-- Medical and dental schools
-- Medical devices
-- Medical research
-- Mental health programs
-- Migrant labor
-- Military air transportation
-- Military law
-- Military personnel
-- Mortgage insurance
-- Mortgages
-- Motion pictures
-- Motor vehicles
-- National defense
-- Natural resources
-- Navigation (air)
-- Navigation (water)
-- Noise control
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nuclear energy
-- Nursing homes
-- Occupational safety and health
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Passports and visas
-- Penalties
-- Privacy
-- Private schools
-- Public lands
-- Radiation protection
-- Real property acquisition
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Reservoirs
-- Rights-of-way
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seals and insignia
-- Seamen
-- Securities
-- Security measures
-- Sex discrimination
-- State and local governments
-- Statistics
-- Student aid
-- Surplus Government property
-- Taxes
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Traffic regulations
-- Transportation
-- Travel and transportation expenses
-- Trusts and trustees
-- Urban areas
-- Vessels
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Wake Island
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Waterways
-- Wildlife
-- Wiretapping and electronic surveillance
-- Women
+- abuse
+- acquisition
+- adult
+- advertising
+- advisory
+- affected
+- aid
+- air
+- aircraft
+- airports
+- alcohol
+- alcoholic
+- alcoholism
+- alimony
+- american
+- archives
+- armed
+- arms
+- assistance
+- aviation
+- benefits
+- beverages
+- biologics
+- blind
+- bridges
+- broadband
+- care
+- cemeteries
+- child
+- civil
+- classified
+- coastal
+- colleges
+- columbia
+- committees
+- communications
+- concessions
+- conscientious
+- construction
+- consumer
+- continental
+- control
+- copyright
+- courts
+- credit
+- crime
+- cultural
+- currencies
+- dams
+- day
+- defense
+- dental
+- department
+- devices
+- disability
+- disadvantaged
+- disaster
+- disorders
+- disposal
+- district
+- elections
+- electronic
+- elementary
+- endangered
+- energy
+- exchange
+- expenses
+- federally
+- fellowships
+- fire
+- fish
+- flood
+- food
+- forces
+- fraud
+- governments
+- guam
+- hazardous
+- highway
+- historic
+- hiv/aids
+- home
+- homeless
+- homes
+- hospitals
+- hostages
+- human
+- impact
+- improvement
+- indians-education
+- indians-lands
+- insignia
+- international
+- inventions
+- iraq
+- island
+- kuwait
+- labor
+- lands
+- law
+- lawyers
+- lebanon
+- legal
+- life
+- local
+- management
+- manpower
+- mariana
+- marine
+- measures
+- medical
+- mental
+- migrant
+- military
+- mortgage
+- mortgages
+- motion
+- munitions
+- natural
+- navigation
+- noise
+- nonprofit
+- northern
+- nuclear
+- nursing
+- objectors
+- occupational
+- officers
+- pacific
+- passports
+- patents
+- personnel
+- pictures
+- pollution
+- preservation
+- prevention
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-housing
+- programs-social
+- programs-veterans
+- property
+- publications
+- radiation
+- rates
+- real
+- records
+- regulations
+- rehabilitation
+- religious
+- reserves
+- reservoirs
+- rights-of-way
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seals
+- seamen
+- secondary
+- services
+- sex
+- shelf
+- species
+- state
+- statements
+- statistics
+- student
+- study
+- subjects
+- substances
+- supply
+- support
+- surplus
+- surveillance
+- taxes
+- teachers
+- technical
+- telecommunications
+- telephone
+- territory
+- threatened
+- traffic
+- training
+- travel
+- treatment
+- trust
+- trustees
+- trusts
+- unions
+- universities
+- urban
+- utilities
+- vehicles
+- veterans
+- virgin
+- visas
+- vocational
+- wake
+- waste
+- watersheds
+- waterways
+- welfare
+- wildlife
+- wiretapping
+- women
+- zone
 name: Department of Defense
 request_time_stats:
   '2008':

--- a/contacts/data/ED.yaml
+++ b/contacts/data/ED.yaml
@@ -37,122 +37,102 @@ departments:
 description: The mission of the Department of Education is to foster educational excellence
   and to ensure equal access to educational opportunity for all.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Aliens
-- American Samoa
-- Armed forces
-- Blind
-- Broadband
-- Business and industry
-- Civil rights
-- Claims
-- Classified information
-- Colleges and universities
-- Communications
-- Community development
-- Consumer protection
-- Copyright
-- Courts
-- Credit
-- Cultural exchange programs
-- Drug abuse
-- Education
-- Education Department
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Equal employment opportunity
-- Federally affected areas
-- Foreign relations
-- Fraud
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Grant programs
-- Grant programs-Indians
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Iraq
-- Juvenile delinquency
-- Kuwait
-- Lebanon
-- Libraries
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-education
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Pacific Islands Trust Territory
-- Penalties
-- Privacy
-- Private schools
-- Public housing
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seals and insignia
-- Securities
-- Selective Service System
-- Sex discrimination
-- State and local governments
-- Student aid
-- Students
-- Teachers
-- Telecommunications
-- Telephone
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- adult
+- affected
+- aid
+- aliens
+- american
+- armed
+- blind
+- broadband
+- classified
+- colleges
+- construction
+- consumer
+- copyright
+- courts
+- cultural
+- delinquency
+- department
+- disadvantaged
+- disposal
+- elementary
+- exchange
+- federally
+- fellowships
+- forces
+- fraud
+- governments
+- guam
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- improvement
+- indians-education
+- insignia
+- international
+- inventions
+- iraq
+- juvenile
+- kuwait
+- lebanon
+- libraries
+- local
+- manpower
+- mariana
+- migrant
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- pacific
+- patents
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-indians
+- programs-social
+- rates
+- rehabilitation
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seals
+- secondary
+- selective
+- service
+- sex
+- state
+- student
+- students
+- study
+- subjects
+- supply
+- system
+- teachers
+- telecommunications
+- telephone
+- territory
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- women
 name: Department of Education
 request_time_stats:
   '2008':

--- a/contacts/data/EEOC.yaml
+++ b/contacts/data/EEOC.yaml
@@ -1323,25 +1323,17 @@ emails:
 - FOIA@EEOC.gov
 fax: 202-663-4639
 keywords:
-- Administrative practice and procedure
-- Advertising
-- Aged
-- Civil rights
-- Conflict of interests
-- Employee benefit plans
-- Equal employment opportunity
-- Ethics
-- Federal buildings and facilities
-- Freedom of information
-- Government employees
-- Individuals with disabilities
-- Intergovernmental relations
-- Investigations
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Retirement
-- Sex discrimination
-- State and local governments
+- advertising
+- benefit
+- employee
+- ethics
+- governments
+- local
+- plans
+- religious
+- retirement
+- sex
+- state
 name: Equal Employment Opportunity Commission
 phone: 202-663-4634
 public_liaison:

--- a/contacts/data/EPA.yaml
+++ b/contacts/data/EPA.yaml
@@ -1162,267 +1162,255 @@ description: The Environmental Protection Agency, with a mission to protect peop
   and the environment from significant health risks, sponsors and conducts research
   and develops and enforces environmental regulations.
 keywords:
-- Accounting
-- Acid rain
-- Administrative practice and procedure
-- Adult education
-- Advertising
-- Aged
-- Agricultural commodities
-- Agriculture
-- Air pollution control
-- Aircraft
-- Airports
-- Alaska
-- Aluminum
-- American Samoa
-- Ammonium sulfate plants
-- Animal feeds
-- Antarctica
-- Armed forces
-- Arsenic
-- Asbestos
-- Batteries
-- Benzene
-- Beryllium
-- Beverages
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Carbon dioxide
-- Carbon monoxide
-- Cement industry
-- Chemicals
-- Civil rights
-- Claims
-- Coal
-- Coastal zone
-- Colleges and universities
-- Communications
-- Community development
-- Confidential business information
-- Conflict of interests
-- Construction industry
-- Consumer protection
-- Continental shelf
-- Copper
-- Copyright
-- Corn
-- Courts
-- Credit
-- Cultural exchange programs
-- Disaster assistance
-- Drug abuse
-- Drugs
-- Dry cleaners
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power plants
-- Electric power rates
-- Electric utilities
-- Electroplating
-- Elementary and secondary education
-- Employment
-- Energy
-- Environmental impact statements
-- Environmental protection
-- Equal educational opportunity
-- Equal employment opportunity
-- Exports
-- Federal buildings and facilities
-- Federally affected areas
-- Fertilizers
-- Fire prevention
-- Flammable materials
-- Fluoride
-- Food additives
-- Foreign relations
-- Forests and forest products
-- Fraud
-- Freedom of information
-- Fuel additives
-- Fuel economy
-- Furniture industry
-- Gasoline
-- Glass and glass products
-- Government contracts
-- Government employees
-- Government procurement
-- Government property management
-- Grains
-- Grant programs
-- Grant programs-Indians
-- Grant programs-education
-- Grant programs-environmental protection
-- Grant programs-health
-- Grant programs-social programs
-- Graphic arts industry
-- Great Lakes
-- Guam
-- Hazardous materials transportation
-- Hazardous substances
-- Hazardous waste
-- Health
-- Health facilities
-- Health insurance
-- Health professions
-- Heaters
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Household appliances
-- Housing
-- Human research subjects
-- Hydrocarbons
-- Imports
-- Indians
-- Indians-education
-- Indians-lands
-- Indians-law
-- Indians-tribal government
-- Individuals with disabilities
-- Insulation
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Iron
-- Kuwait
-- Labeling
-- Laboratories
-- Lead
-- Lead poisoning
-- Lebanon
-- Lime
-- Livestock
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Mass transportation
-- Meat and meat products
-- Mercury
-- Metallic and nonmetallic mineral processing plants
-- Metals
-- Methane
-- Migrant labor
-- Milk
-- Mines
-- Mortgage insurance
-- Mortgages
-- Motor carriers
-- Motor vehicle pollution
-- Motor vehicle safety
-- Motor vehicles
-- National parks
-- Natural gas
-- Natural resources
-- Navigation (water)
-- Nitric acid plants
-- Nitrogen dioxide
-- Nitrogen oxides
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nuclear energy
-- Nuclear materials
-- Nuclear power plants and reactors
-- Occupational safety and health
-- Oil imports
-- Oil pollution
-- Organization and functions (Government agencies)
-- Ozone
-- Pacific Islands Trust Territory
-- Packaging and containers
-- Paper and paper products industry
-- Particulate matter
-- Paving and roofing materials
-- Penalties
-- Petroleum
-- Phosphate
-- Plants
-- Plastics materials and synthetics
-- Plutonium
-- Poison prevention
-- Polymers
-- Poultry and poultry products
-- Privacy
-- Private schools
-- Public health
-- Quarantine
-- Radiation protection
-- Radioactive materials
-- Radionuclides
-- Radon
-- Railroads
-- Reclamation
-- Recycling
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Reservoirs
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Securities
-- Security measures
-- Sewage disposal
-- Sex discrimination
-- Silver
-- Small businesses
-- State and local governments
-- Steel
-- Student aid
-- Sulfur
-- Sulfur oxides
-- Sulfuric acid plants
-- Superfund
-- Surety bonds
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Tires
-- Toys
-- Transportation
-- Treaties
-- Uranium
-- Urban areas
-- Urethane
-- Utilities
-- Vessels
-- Veterans
-- Vinyl
-- Vinyl chloride
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Volatile organic compounds
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Waterways
-- Wilderness areas
-- Women
-- Wool
-- Zinc
+- acid
+- additives
+- adult
+- advertising
+- affected
+- agricultural
+- aid
+- aircraft
+- airports
+- alaska
+- aluminum
+- american
+- ammonium
+- animal
+- antarctica
+- appliances
+- armed
+- arsenic
+- arts
+- asbestos
+- batteries
+- benzene
+- beryllium
+- beverages
+- blind
+- broadband
+- businesses
+- carbon
+- cement
+- chemicals
+- chloride
+- cleaners
+- coal
+- coastal
+- colleges
+- commodities
+- compounds
+- confidential
+- construction
+- consumer
+- containers
+- continental
+- copper
+- copyright
+- corn
+- courts
+- cultural
+- dioxide
+- disadvantaged
+- disaster
+- disposal
+- drugs
+- dry
+- economy
+- electroplating
+- elementary
+- energy
+- exchange
+- exports
+- federally
+- feeds
+- fellowships
+- fertilizers
+- fire
+- flammable
+- fluoride
+- food
+- forces
+- forest
+- forests
+- fraud
+- fuel
+- furniture
+- gas
+- gasoline
+- glass
+- governments
+- grains
+- graphic
+- great
+- guam
+- hazardous
+- heaters
+- highways
+- home
+- homeless
+- hospitals
+- hostages
+- household
+- human
+- hydrocarbons
+- impact
+- imports
+- improvement
+- indians-education
+- indians-lands
+- indians-law
+- indians-tribal
+- industry
+- insulation
+- international
+- inventions
+- iraq
+- iron
+- kuwait
+- labeling
+- laboratories
+- lakes
+- lead
+- lebanon
+- lime
+- livestock
+- local
+- manpower
+- mariana
+- mass
+- materials
+- matter
+- measures
+- meat
+- mercury
+- metallic
+- metals
+- methane
+- migrant
+- milk
+- mineral
+- mines
+- monoxide
+- mortgage
+- mortgages
+- motor
+- natural
+- navigation
+- nitric
+- nitrogen
+- nonmetallic
+- nonprofit
+- northern
+- nuclear
+- occupational
+- oil
+- organic
+- oxides
+- ozone
+- pacific
+- packaging
+- paper
+- parks
+- particulate
+- patents
+- paving
+- petroleum
+- phosphate
+- plants
+- plastics
+- plutonium
+- poison
+- poisoning
+- pollution
+- polymers
+- poultry
+- power
+- prevention
+- private
+- processing
+- procurement
+- products
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-environmental
+- programs-indians
+- programs-social
+- protection
+- quarantine
+- radiation
+- radioactive
+- radionuclides
+- radon
+- railroads
+- rain
+- rates
+- reactors
+- reclamation
+- recycling
+- rehabilitation
+- religious
+- reservoirs
+- roads
+- roofing
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- secondary
+- sewage
+- sex
+- shelf
+- silver
+- small
+- state
+- statements
+- steel
+- student
+- study
+- subjects
+- substances
+- sulfate
+- sulfur
+- sulfuric
+- superfund
+- supply
+- surety
+- synthetics
+- teachers
+- technical
+- telecommunications
+- telephone
+- territory
+- tires
+- toys
+- training
+- treaties
+- treatment
+- trust
+- universities
+- uranium
+- urban
+- urethane
+- utilities
+- vehicle
+- vehicles
+- veterans
+- vinyl
+- virgin
+- vocational
+- volatile
+- waste
+- watersheds
+- waterways
+- wilderness
+- women
+- wool
+- zinc
+- zone
 name: Environmental Protection Agency
 phone: 202-566-1667
 public_liaison:

--- a/contacts/data/Ex-Im Bank.yaml
+++ b/contacts/data/Ex-Im Bank.yaml
@@ -52,20 +52,11 @@ description: An independent federal agency, the Export-Import Bank assists Ameri
   loan guarantees and insurance. The focus of the Export-Import Bank is on assisting
   small businesses.
 keywords:
-- Administrative practice and procedure
-- Classified information
-- Conflict of interests
-- Exports
-- Government contracts
-- Government employees
-- Government publications
-- Grant programs
-- Health facilities
-- Health insurance
-- Health professions
-- Loan programs
-- Reporting and recordkeeping requirements
-- Sunshine Act
+- act
+- classified
+- exports
+- publications
+- sunshine
 name: Export-Import Bank of the U.S.
 request_time_stats:
   '2008':

--- a/contacts/data/FCA.yaml
+++ b/contacts/data/FCA.yaml
@@ -93,58 +93,45 @@ description: The Farm Credit Administration is an independent financial regulato
   agency that oversees the various lending institutions and banks serving agricultural
   and rural America.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Advertising
-- Aged
-- Agriculture
-- Archives and records
-- Bank deposit insurance
-- Civil rights
-- Claims
-- Classified information
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Courts
-- Credit
-- Credit unions
-- Crime
-- Currency
-- Equal employment opportunity
-- Exports
-- Fair housing
-- Federal Reserve System
-- Federal buildings and facilities
-- Flood insurance
-- Foreign banking
-- Foreign trade
-- Freedom of information
-- Government employees
-- Government securities
-- Holding companies
-- Individuals with disabilities
-- Insurance
-- Investigations
-- Investments
-- Loan programs-housing and community development
-- Marital status discrimination
-- Mortgages
-- National banks
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Rural areas
-- Savings associations
-- Securities
-- Sex discrimination
-- Signs and symbols
-- Sunshine Act
-- Surety bonds
-- Technical assistance
-- Wages
+- act
+- advertising
+- archives
+- associations
+- bank
+- banking
+- banks
+- classified
+- companies
+- confidential
+- consumer
+- courts
+- credit
+- crime
+- currency
+- deposit
+- discrimination
+- exports
+- fair
+- federal
+- flood
+- holding
+- investments
+- marital
+- mortgages
+- religious
+- reserve
+- rural
+- savings
+- securities
+- sex
+- signs
+- status
+- sunshine
+- surety
+- symbols
+- system
+- technical
+- unions
 name: Farm Credit Administration
 request_time_stats:
   '2008':

--- a/contacts/data/FCC.yaml
+++ b/contacts/data/FCC.yaml
@@ -123,88 +123,77 @@ description: An independent federal agency reporting to Congress, the Federal Co
   radio, television, satellite and wire. The goal of the Commission is to promote
   connectivity and ensure a robust and competitive market.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Advertising
-- Advisory committees
-- Air transportation
-- Airports
-- Alaska
-- Authority delegations (Government agencies)
-- Aviation safety
-- Broadband
-- Business and industry
-- Cable television
-- Civil defense
-- Civil rights
-- Claims
-- Classified information
-- Common carriers
-- Communications
-- Communications common carriers
-- Communications equipment
-- Computer technology
-- Conflict of interests
-- Consumer protection
-- Cuba
-- Defense communications
-- Disaster assistance
-- Drug abuse
-- Education
-- Emergency medical services
-- Environmental impact statements
-- Equal access to justice
-- Equal employment opportunity
-- Federal Communications Commission
-- Federal buildings and facilities
-- Foreign relations
-- Fraud
-- Freedom of information
-- Government employees
-- Government publications
-- Great Lakes
-- Health facilities
-- Household appliances
-- Imports
-- Income taxes
-- Indemnity payments
-- Individuals with disabilities
-- Intergovernmental relations
-- Investigations
-- Labeling
-- Lawyers
-- Libraries
-- Marine safety
-- Medical devices
-- Metric system
-- Mexico
-- Organization and functions (Government agencies)
-- Penalties
-- Political candidates
-- Postal Service
-- Privacy
-- Puerto Rico
-- Radio
-- Recordings
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Satellites
-- Schools
-- Scientific equipment
-- Securities
-- Security measures
-- Sunshine Act
-- Telecommunications
-- Telegraph
-- Telephone
-- Television
-- Uniform System of Accounts
-- Vessels
-- Volunteers
-- Wages
-- Weather
-- Wiretapping and electronic surveillance
+- access
+- accounts
+- act
+- advertising
+- advisory
+- airports
+- alaska
+- appliances
+- authority
+- aviation
+- broadband
+- cable
+- candidates
+- carriers
+- classified
+- commission
+- committees
+- common
+- communications
+- computer
+- consumer
+- cuba
+- defense
+- delegations
+- devices
+- disaster
+- electronic
+- emergency
+- equipment
+- federal
+- fraud
+- great
+- household
+- impact
+- imports
+- indemnity
+- justice
+- labeling
+- lakes
+- lawyers
+- libraries
+- marine
+- measures
+- medical
+- metric
+- mexico
+- payments
+- political
+- postal
+- publications
+- puerto
+- radio
+- recordings
+- rico
+- rural
+- satellites
+- scientific
+- service
+- services
+- statements
+- sunshine
+- surveillance
+- system
+- telecommunications
+- telegraph
+- telephone
+- television
+- uniform
+- volunteers
+- weather
+- wiretapping
 name: Federal Communications Commission
 request_time_stats:
   '2008':

--- a/contacts/data/FCSIC.yaml
+++ b/contacts/data/FCSIC.yaml
@@ -84,10 +84,7 @@ departments:
 description: The Farm Credit System Insurance Corporation ensures timely payment of
   interest and principal on Systemwide and consolidated bonds and other obligations
   issued by Farm Credit System banks.
-keywords:
-- Insurance
-- Penalties
-- Reporting and recordkeeping requirements
+keywords: []
 name: Farm Credit System Insurance Corporation
 request_time_stats:
   '2008':

--- a/contacts/data/FDIC.yaml
+++ b/contacts/data/FDIC.yaml
@@ -119,79 +119,66 @@ description: FDIC responds to questions about federal deposit insurance coverage
   handles complaints and inquiries about FDIC-insured state banks which are not members
   of the Federal Reserve System.
 keywords:
-- Accountants
-- Accounting
-- Administrative practice and procedure
-- Advertising
-- Aged
-- Agriculture
-- Antitrust
-- Authority delegations (Government agencies)
-- Bank deposit insurance
-- Brokers
-- Business and industry
-- Civil rights
-- Claims
-- Communications
-- Community development
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Credit
-- Credit unions
-- Crime
-- Currency
-- Employment
-- Equal access to justice
-- Equal employment opportunity
-- Ethics
-- Exports
-- Fair housing
-- Federal Reserve System
-- Flood insurance
-- Foreign banking
-- Foreign currencies
-- Foreign trade
-- Fraud
-- Freedom of information
-- Gambling
-- Government contracts
-- Government employees
-- Government securities
-- Holding companies
-- Indemnity payments
-- Individuals with disabilities
-- Insurance
-- Insurance companies
-- Investigations
-- Investment companies
-- Investments
-- Law enforcement
-- Lawyers
-- Legal services
-- Loan programs
-- Loan programs-housing and community development
-- Manufactured homes
-- Minority businesses
-- Mortgages
-- National banks
-- Nonprofit organizations
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Reporting and recordkeeping requirements
-- Rural areas
-- Savings associations
-- Securities
-- Security measures
-- Signs and symbols
-- Surety bonds
-- Trade practices
-- Trusts and trustees
-- Truth in lending
-- United States investments abroad
-- Wages
-- Women
+- abroad
+- access
+- accountants
+- advertising
+- antitrust
+- associations
+- authority
+- bank
+- banking
+- banks
+- brokers
+- businesses
+- companies
+- confidential
+- consumer
+- credit
+- crime
+- currencies
+- currency
+- delegations
+- deposit
+- ethics
+- exports
+- fair
+- flood
+- fraud
+- gambling
+- holding
+- homes
+- indemnity
+- investment
+- investments
+- justice
+- lawyers
+- legal
+- lending
+- manufactured
+- measures
+- minority
+- mortgages
+- nonprofit
+- payments
+- practices
+- reserve
+- rural
+- savings
+- securities
+- services
+- signs
+- states
+- surety
+- symbols
+- system
+- trade
+- trustees
+- trusts
+- truth
+- unions
+- united
+- women
 name: Federal Deposit Insurance Corporation
 request_time_stats:
   '2008':

--- a/contacts/data/FEC.yaml
+++ b/contacts/data/FEC.yaml
@@ -111,26 +111,18 @@ description: The Federal Election Commission enforces federal campaign finance l
   including monitoring donation prohibitions and limits and overseeing public funding
   for presidential campaigns.
 keywords:
-- Administrative practice and procedure
-- Archives and records
-- Business and industry
-- Campaign funds
-- Conflict of interests
-- Credit
-- Elections
-- Freedom of information
-- Government contracts
-- Government employees
-- Labor
-- Law enforcement
-- Nonprofit organizations
-- Penalties
-- Political activities (Government employees)
-- Political candidates
-- Political committees and parties
-- Privacy
-- Reporting and recordkeeping requirements
-- Sunshine Act
+- act
+- activities
+- archives
+- campaign
+- candidates
+- committees
+- elections
+- funds
+- nonprofit
+- parties
+- political
+- sunshine
 name: Federal Election Commission
 request_time_stats:
   '2008':

--- a/contacts/data/FERC.yaml
+++ b/contacts/data/FERC.yaml
@@ -112,47 +112,44 @@ description: The Federal Energy Regulatory Commission regulates interstate trans
   of electricity, natural gas, and oil, and also regulates hydropower projects and
   natural gas terminals.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Alaska
-- Authority delegations (Government agencies)
-- Civil defense
-- Classified information
-- Confidential business information
-- Conflict of interests
-- Continental shelf
-- Dams
-- Electric power
-- Electric power plants
-- Electric power rates
-- Electric utilities
-- Environmental impact statements
-- Environmental protection
-- Exports
-- Freedom of information
-- Government employees
-- Hazardous substances
-- Historic preservation
-- Imports
-- Indians-lands
-- Investigations
-- Livestock
-- Maritime carriers
-- Natural gas
-- Natural resources
-- Organization and functions (Government agencies)
-- Penalties
-- Pipelines
-- Privacy
-- Public lands
-- Reporting and recordkeeping requirements
-- Seals and insignia
-- Securities
-- Sunshine Act
-- Uniform System of Accounts
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
+- accounts
+- act
+- alaska
+- authority
+- classified
+- confidential
+- continental
+- dams
+- defense
+- delegations
+- disposal
+- exports
+- gas
+- hazardous
+- historic
+- impact
+- imports
+- indians-lands
+- insignia
+- lands
+- livestock
+- maritime
+- natural
+- pipelines
+- plants
+- power
+- preservation
+- rates
+- seals
+- shelf
+- statements
+- substances
+- sunshine
+- system
+- treatment
+- uniform
+- utilities
+- waste
 name: Federal Energy Regulatory Commission
 request_time_stats:
   '2008':

--- a/contacts/data/FFIEC.yaml
+++ b/contacts/data/FFIEC.yaml
@@ -36,9 +36,6 @@ description: The Federal Financial Institutions Examination Council is an intera
   body that seeks to standardize the oversight criteria and methods of the various
   financial regulatory bodies.
 keywords:
-- Administrative practice and procedure
-- Freedom of information
-- Mortgages
-- Reporting and recordkeeping requirements
+- mortgages
 name: Federal Financial Institutions Examination Council
 usa_id: '49290'

--- a/contacts/data/FHFA.yaml
+++ b/contacts/data/FHFA.yaml
@@ -64,53 +64,43 @@ description: The Federal Housing Finance Agency provides supervision, regulation
   and housing mission oversight of Fannie Mae, Freddie Mac and the Federal Home Loan
   Banks.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Advertising
-- Agriculture
-- Archives and records
-- Claims
-- Community development
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Courts
-- Credit
-- Credit unions
-- Crime
-- Currency
-- Elections
-- Equal access to justice
-- Equal employment opportunity
-- Ethics
-- Federal Reserve System
-- Federal home loan banks
-- Flood insurance
-- Foreign banking
-- Freedom of information
-- Government contracts
-- Government employees
-- Government securities
-- Holding companies
-- Housing
-- Insurance
-- Intergovernmental relations
-- Investments
-- Minority businesses
-- Mortgages
-- National banks
-- Nonprofit organizations
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Reporting and recordkeeping requirements
-- Savings associations
-- Seals and insignia
-- Securities
-- Sunshine Act
-- Trade practices
-- Truth in lending
-- Wages
+- access
+- act
+- advertising
+- archives
+- associations
+- banking
+- banks
+- businesses
+- companies
+- confidential
+- consumer
+- courts
+- credit
+- crime
+- currency
+- elections
+- ethics
+- federal
+- flood
+- holding
+- home
+- insignia
+- investments
+- justice
+- lending
+- minority
+- mortgages
+- nonprofit
+- practices
+- reserve
+- savings
+- seals
+- securities
+- sunshine
+- system
+- truth
+- unions
 name: Federal Housing Finance Agency
 request_time_stats:
   '2009':

--- a/contacts/data/FLRA.yaml
+++ b/contacts/data/FLRA.yaml
@@ -816,11 +816,8 @@ emails:
 - solmail@flra.gov
 fax: 202-343-1007
 keywords:
-- Administrative practice and procedure
-- Conflict of interests
-- Equal access to justice
-- Government employees
-- Labor management relations
+- access
+- justice
 name: Federal Labor Relations Authority
 phone: 202-218-7770
 public_liaison:

--- a/contacts/data/FMCS.yaml
+++ b/contacts/data/FMCS.yaml
@@ -116,19 +116,10 @@ description: The Federal Mediation and Conciliation Service is an independent ag
   that provides mediation and other conflict resolution services for managing and
   enhancing labor-management relationships.
 keywords:
-- Administrative practice and procedure
-- Freedom of information
-- Government employees
-- Grant programs
-- Health facilities
-- Health insurance
-- Health professions
-- Hostages
-- Iraq
-- Kuwait
-- Labor management relations
-- Lebanon
-- Loan programs
+- hostages
+- iraq
+- kuwait
+- lebanon
 name: Federal Mediation and Conciliation Service
 request_time_stats:
   '2008':

--- a/contacts/data/FMSHRC.yaml
+++ b/contacts/data/FMSHRC.yaml
@@ -117,20 +117,13 @@ description: The Federal Mine Safety and Health Review Commission is an independ
   agency that administers trials and hears appeals of disputes relating directly to
   the Mine Safety and Health Act of 1977.
 keywords:
-- Administrative practice and procedure
-- Civil rights
-- Claims
-- Equal access to justice
-- Equal employment opportunity
-- Federal buildings and facilities
-- Freedom of information
-- Individuals with disabilities
-- Lawyers
-- Mine safety and health
-- Penalties
-- Privacy
-- Sunshine Act
-- Whistleblowing
+- access
+- act
+- justice
+- lawyers
+- mine
+- sunshine
+- whistleblowing
 name: Federal Mine Safety and Health Review Commission
 request_time_stats:
   '2008':

--- a/contacts/data/FRB.yaml
+++ b/contacts/data/FRB.yaml
@@ -113,80 +113,72 @@ departments:
 description: The Federal Reserve is the central bank of the United States. It formulates
   and administers credit and monetary policy.
 keywords:
-- Accountants
-- Accounting
-- Administrative practice and procedure
-- Advertising
-- Aged
-- Agriculture
-- Antitrust
-- Authority delegations (Government agencies)
-- Bank deposit insurance
-- Brokers
-- Business and industry
-- Civil rights
-- Claims
-- Commodity futures
-- Community development
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Credit
-- Credit unions
-- Crime
-- Currency
-- Electronic funds transfers
-- Equal access to justice
-- Equal employment opportunity
-- Ethics
-- Exports
-- Federal Open Market Committee
-- Federal Reserve System
-- Federal buildings and facilities
-- Flood insurance
-- Foreign banking
-- Foreign currencies
-- Foreign relations
-- Foreign trade
-- Freedom of information
-- Gambling
-- Government employees
-- Government property
-- Government securities
-- Holding companies
-- Individuals with disabilities
-- Insurance
-- Insurance companies
-- Intergovernmental relations
-- Investigations
-- Investment companies
-- Investments
-- Law enforcement
-- Lawyers
-- Loan programs-housing and community development
-- Manufactured homes
-- Marital status discrimination
-- Mortgages
-- National banks
-- Nonprofit organizations
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Rural areas
-- Savings associations
-- Securities
-- Security measures
-- Sex discrimination
-- Sunshine Act
-- Surety bonds
-- Trade practices
-- Trusts and trustees
-- Truth in lending
-- Truth in savings
-- United States investments abroad
-- Wages
+- abroad
+- access
+- accountants
+- act
+- advertising
+- antitrust
+- associations
+- authority
+- bank
+- banking
+- banks
+- brokers
+- committee
+- commodity
+- companies
+- confidential
+- consumer
+- credit
+- crime
+- currencies
+- currency
+- delegations
+- deposit
+- discrimination
+- electronic
+- ethics
+- exports
+- federal
+- flood
+- foreign
+- funds
+- futures
+- gambling
+- holding
+- homes
+- investment
+- investments
+- justice
+- lawyers
+- lending
+- manufactured
+- marital
+- market
+- measures
+- mortgages
+- nonprofit
+- open
+- practices
+- religious
+- reserve
+- rural
+- savings
+- securities
+- sex
+- states
+- status
+- sunshine
+- surety
+- system
+- trade
+- transfers
+- trustees
+- trusts
+- truth
+- unions
+- united
 name: Federal Reserve System
 request_time_stats:
   '2008':

--- a/contacts/data/FRTIB.yaml
+++ b/contacts/data/FRTIB.yaml
@@ -76,24 +76,21 @@ departments:
 description: The Federal Retirement Thrift Investment Board administers the Thrift
   Savings Plan, a tax-deferred retirement account similar to a 401(k).
 keywords:
-- Administrative practice and procedure
-- Alimony
-- Child support
-- Claims
-- Courts
-- Credit
-- District of Columbia
-- Employee benefit plans
-- Freedom of information
-- Government employees
-- Income taxes
-- Military personnel
-- Privacy
-- Reporting and recordkeeping requirements
-- Retirement
-- Sunshine Act
-- Taxes
-- Wages
+- act
+- alimony
+- benefit
+- child
+- columbia
+- courts
+- district
+- employee
+- military
+- personnel
+- plans
+- retirement
+- sunshine
+- support
+- taxes
 name: Federal Retirement Thrift Investment Board
 request_time_stats:
   '2010':

--- a/contacts/data/FTC.yaml
+++ b/contacts/data/FTC.yaml
@@ -116,71 +116,64 @@ description: 'The Federal Trade Commission works to prevent fraudulent, deceptiv
   and unfair business practices. They also provide information to help consumers spot,
   stop, and avoid scams and fraud. '
 keywords:
-- Administrative practice and procedure
-- Advertising
-- Antitrust
-- Bank deposit insurance
-- Blind
-- Brokers
-- Business and industry
-- Civil rights
-- Claims
-- Clothing
-- Communications
-- Computer technology
-- Consumer protection
-- Credit
-- Credit unions
-- Electronic products
-- Employment
-- Energy conservation
-- Environmental protection
-- Equal access to justice
-- Equal employment opportunity
-- Federal buildings and facilities
-- Foods
-- Foreign banking
-- Freedom of information
-- Fuel economy
-- Furniture industry
-- Furs
-- Gasoline
-- Government employees
-- Government procurement
-- Health records
-- Hobbies
-- Holding companies
-- Household appliances
-- Insulation
-- Intergovernmental relations
-- Investigations
-- Investment companies
-- Labeling
-- Law
-- Lawyers
-- Leather and leather products industry
-- Medical devices
-- Mortgages
-- Motor vehicles
-- National banks
-- Ophthalmic goods and services
-- Organization and functions (Government agencies)
-- Packaging and containers
-- Penalties
-- Privacy
-- Reporting and recordkeeping requirements
-- Safety
-- Savings associations
-- Science and technology
-- Securities
-- Shoes
-- Sunshine Act
-- Telephone
-- Textiles
-- Tobacco
-- Trade practices
-- Wages
-- Youth
+- access
+- act
+- advertising
+- antitrust
+- appliances
+- associations
+- bank
+- banking
+- banks
+- blind
+- brokers
+- clothing
+- companies
+- computer
+- conservation
+- consumer
+- containers
+- credit
+- deposit
+- devices
+- economy
+- electronic
+- energy
+- foods
+- fuel
+- furniture
+- furs
+- gasoline
+- goods
+- hobbies
+- holding
+- household
+- industry
+- insulation
+- investment
+- justice
+- labeling
+- lawyers
+- leather
+- medical
+- mortgages
+- ophthalmic
+- packaging
+- practices
+- procurement
+- products
+- savings
+- science
+- services
+- shoes
+- sunshine
+- technology
+- telephone
+- textiles
+- tobacco
+- unions
+- vehicles
+- youth
 name: Federal Trade Commission
 request_time_stats:
   '2008':

--- a/contacts/data/GSA.yaml
+++ b/contacts/data/GSA.yaml
@@ -40,146 +40,153 @@ description: The General Services Administration manages federal property, inclu
   operating and maintaining buildings, supplies and transportation acquisition, and
   communications management.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Advisory committees
-- Aged
-- Agriculture
-- Aircraft
-- Airports
-- Antitrust
-- Architecture
-- Archives and records
-- Artwork in Government Buildings
-- Assisted Acquisition
-- Aviation safety
-- Blind
-- Building Maintenance Reports
-- Building Performance
-- Buildings and facilities
-- Child Care Centers
-- Civil rights
-- Claims
-- Colleges and universities
-- Computer technology
-- Concessions
-- Conflict of interests
-- Construction
-- Construction or Renovation Costs
-- Contract Task Orders
-- Contracts
-- Contractual Awards and selection
-- Courthouses
-- Crime
-- Donation Program
-- Education
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Elevator Service Reports
-- Energy Efficiency
-- Energy conservation
-- Equal educational opportunity
-- Equal employment opportunity
-- Federal Acquisition Regulation (FAR)
-- Federal Building Sales
-- Federal Buildings
-- Federal Management Regulation (FMR)
-- Federal Travel Regulation (FTR)
-- Federal buildings and facilities
-- Fire prevention
-- First Class/Premium Travel
-- Fleet Management
-- Foreign relations
-- Fraud
-- Freight
-- Freight forwarders
-- GSA Advantage Program
-- GSA Global Supply
-- GSA Multiple Award Schedule
-- GSA Pricing of goods and services offered
-- GSA Prospectus
-- GSA Schedules Program
-- GSA/Congressional and Intergovernmental Affairs Communications
-- GSA/Federal Government Per Diem Program
-- General Schedule Contracts
-- General Services Acquisition Manual (GSAM)
-- Government Purchase Card Program
-- Government Social Media
-- Government Travel Card Program
-- Government Travel Charge Cards
-- Government Travel Information - Premium Travel
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Governmentwide Policies and Regulations
-- Governmentwide Policy and Regulation
-- Grant programs
-- Grant programs-education
-- Grant programs-social programs
-- Green Buildings
-- Health care
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Historical Building Preservation
-- Homeless
-- Hostages
-- Incident/Accident Reports
-- Income taxes
-- Individuals with disabilities
-- Intergovernmental relations
-- Investigations
-- Iraq
-- Kuwait
-- LEED Certified Buildings
-- Land Port of Entry Construction/Modifications
-- Leased Vehicle Fleet
-- Lebanon
-- Loan programs
-- Mass transportation
-- Monuments - Historical Preservation
-- Motor vehicles
-- Moving of household goods
-- Occupational safety and health
-- Operation and Maintenance Costs
-- Owned Vehicle Fleet
-- Parking
-- Personal Property Management
-- Privacy
-- Procurement
-- Property Auction - Buildings/land/lighthouses
-- Property Disposal
-- Property Donation
-- Railroads
-- Real property acquisition
-- Religious discrimination
-- Renovation
-- Reporting and recordkeeping requirements
-- Security measures
-- Sex discrimination
-- Small Business
-- Small businesses
-- Student aid
-- Supply Auction
-- Surplus Government property
-- Taxes
-- Telecommunications
-- Transportation
-- Travel
-- Travel Program Information
-- Travel and transportation expenses
-- Utilities
-- Veterans
-- Wages
-- Women
-- federal contracts
-- government forms
-- purchase cards
+- '-'
+- acquisition
+- advantage
+- advisory
+- affairs
+- aid
+- aircraft
+- airports
+- antitrust
+- architecture
+- archives
+- artwork
+- assisted
+- auction
+- aviation
+- award
+- awards
+- blind
+- building
+- buildings
+- buildings/land/lighthouses
+- businesses
+- card
+- cards
+- care
+- centers
+- certified
+- charge
+- child
+- class/premium
+- colleges
+- committees
+- computer
+- concessions
+- conservation
+- construction
+- construction/modifications
+- contract
+- contracts
+- contractual
+- costs
+- courthouses
+- crime
+- diem
+- disposal
+- donation
+- efficiency
+- elevator
+- energy
+- entry
+- expenses
+- far
+- federal
+- fire
+- first
+- fleet
+- fmr
+- forms
+- forwarders
+- fraud
+- freight
+- ftr
+- general
+- global
+- goods
+- governmentwide
+- green
+- gsa
+- gsa/congressional
+- gsa/federal
+- gsam
+- highways
+- historical
+- homeless
+- hostages
+- household
+- incident/accident
+- intergovernmental
+- iraq
+- kuwait
+- land
+- leased
+- lebanon
+- leed
+- maintenance
+- management
+- manual
+- mass
+- measures
+- media
+- monuments
+- moving
+- multiple
+- occupational
+- offered
+- operation
+- orders
+- owned
+- parking
+- per
+- performance
+- personal
+- policies
+- policy
+- port
+- premium
+- preservation
+- prevention
+- pricing
+- procurement
+- program
+- programs-education
+- programs-social
+- property
+- prospectus
+- purchase
+- railroads
+- real
+- regulation
+- regulations
+- religious
+- renovation
+- reports
+- roads
+- sales
+- schedule
+- schedules
+- selection
+- service
+- services
+- sex
+- small
+- social
+- student
+- study
+- supply
+- surplus
+- task
+- taxes
+- telecommunications
+- travel
+- universities
+- utilities
+- vehicle
+- vehicles
+- veterans
+- women
 name: General Services Administration
 request_time_stats:
   '2008':

--- a/contacts/data/HHS.yaml
+++ b/contacts/data/HHS.yaml
@@ -282,45 +282,34 @@ departments:
     phone:
     - 888-747-1861
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Adoption and foster care
-  - Child support
-  - Child welfare
-  - Claims
-  - Computer technology
-  - Day care
-  - Dental health
-  - Education of disadvantaged
-  - Employment
-  - Fraud
-  - Grant programs
-  - Grant programs-health
-  - Grant programs-social programs
-  - Health care
-  - Health facilities
-  - Health professions
-  - Homeless
-  - Immigration
-  - Indians
-  - Individuals with disabilities
-  - Loan programs-social programs
-  - Manpower training programs
-  - Maternal and child health
-  - Medicaid
-  - Medicare
-  - Mental health programs
-  - Nutrition
-  - Penalties
-  - Public assistance programs
-  - Real property acquisition
-  - Reporting and recordkeeping requirements
-  - Social security
-  - Technical assistance
-  - Transportation
-  - Unemployment compensation
-  - Vocational education
-  - Youth
+  - acquisition
+  - adoption
+  - care
+  - child
+  - compensation
+  - computer
+  - day
+  - dental
+  - disadvantaged
+  - foster
+  - fraud
+  - homeless
+  - immigration
+  - manpower
+  - maternal
+  - medicaid
+  - medicare
+  - mental
+  - nutrition
+  - programs-social
+  - real
+  - social
+  - support
+  - technical
+  - training
+  - unemployment
+  - welfare
+  - youth
   name: Administration for Children and Families
   phone: 888-747-1861
   public_liaison:
@@ -539,22 +528,18 @@ departments:
     phone:
     - 770-488-6399
   keywords:
-  - Aliens
-  - Biologics
-  - Coal
-  - Grant programs-health
-  - Health care
-  - Health facilities
-  - Laboratories
-  - Medicaid
-  - Medicare
-  - Mine safety and health
-  - Packaging and containers
-  - Passports and visas
-  - Penalties
-  - Public health
-  - Reporting and recordkeeping requirements
-  - Transportation
+  - aliens
+  - biologics
+  - care
+  - coal
+  - containers
+  - laboratories
+  - medicaid
+  - medicare
+  - mine
+  - packaging
+  - passports
+  - visas
   name: Centers for Disease Control and Prevention
   phone: 770-488-6399
   public_liaison:
@@ -705,74 +690,67 @@ departments:
     phone:
     - 410-786-5353
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Advertising
-  - Advisory committees
-  - Aged
-  - Aid to Families with Dependent Children
-  - Brokers
-  - Child support
-  - Civil rights
-  - Claims
-  - Computer technology
-  - Consumer protection
-  - Drugs
-  - Education of disadvantaged
-  - Emergency medical services
-  - Employee benefit plans
-  - Excise taxes
-  - Family planning
-  - Fraud
-  - Freedom of information
-  - Grant programs
-  - Grant programs-health
-  - Grant programs-social programs
-  - Guam
-  - Health
-  - Health care
-  - Health facilities
-  - Health insurance
-  - Health maintenance organizations (HMO)
-  - Health professions
-  - Health records
-  - Hospice care
-  - Hospitals
-  - Indians
-  - Individuals with disabilities
-  - Intergovernmental relations
-  - Investigations
-  - Kidney diseases
-  - Laboratories
-  - Loan programs
-  - Loan programs-health
-  - Maternal and child health
-  - Medicaid
-  - Medical devices
-  - Medical research
-  - Medicare
-  - Nursing homes
-  - Nutrition
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Prescription drugs
-  - Privacy
-  - Public assistance programs
-  - Public health
-  - Puerto Rico
-  - Reporting and recordkeeping requirements
-  - Rural areas
-  - Safety
-  - Social security
-  - State and local governments
-  - Sunshine Act
-  - Supplemental Security Income (SSI)
-  - Technical assistance
-  - Virgin Islands
-  - Wages
-  - Women
-  - X-rays
-  - Youth
+  - act
+  - advertising
+  - advisory
+  - aid
+  - benefit
+  - brokers
+  - care
+  - child
+  - children
+  - committees
+  - computer
+  - consumer
+  - dependent
+  - devices
+  - disadvantaged
+  - diseases
+  - drugs
+  - emergency
+  - employee
+  - excise
+  - families
+  - family
+  - fraud
+  - governments
+  - guam
+  - hmo
+  - homes
+  - hospice
+  - hospitals
+  - kidney
+  - laboratories
+  - local
+  - maintenance
+  - maternal
+  - medicaid
+  - medical
+  - medicare
+  - nursing
+  - nutrition
+  - planning
+  - plans
+  - prescription
+  - programs-health
+  - programs-social
+  - public
+  - puerto
+  - rico
+  - rural
+  - security
+  - services
+  - social
+  - ssi
+  - state
+  - sunshine
+  - supplemental
+  - support
+  - technical
+  - virgin
+  - women
+  - x-rays
+  - youth
   name: Center for Medicare and Medicaid Services
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -886,87 +864,85 @@ departments:
     The FDA also provides accurate, science-based health information to the public.
   fax: 301-827-9267
   keywords:
-  - Adhesives
-  - Administrative practice and procedure
-  - Advertising
-  - Advisory committees
-  - Animal drugs
-  - Animal feeds
-  - Animal foods
-  - Authority delegations (Government agencies)
-  - Beverages
-  - Biologics
-  - Blood
-  - Cancer
-  - Color additives
-  - Communicable diseases
-  - Computer technology
-  - Confidential business information
-  - Conflict of interests
-  - Consumer protection
-  - Cosmetics
-  - Courts
-  - Cream
-  - Dietary foods
-  - Drugs
-  - Eggs and egg products
-  - Electronic products
-  - Environmental impact statements
-  - Exports
-  - Fish
-  - Food additives
-  - Food grades and standards
-  - Food labeling
-  - Food packaging
-  - Foods
-  - Foreign relations
-  - Freedom of information
-  - Fruit juices
-  - Fruits
-  - Government employees
-  - HIV/AIDS
-  - Health
-  - Health care
-  - Health facilities
-  - Health records
-  - Hospitals
-  - Human research subjects
-  - Immunization
-  - Imports
-  - Intergovernmental relations
-  - Investigations
-  - Labeling
-  - Laboratories
-  - Medical devices
-  - Medical research
-  - Milk
-  - News media
-  - Nutrition
-  - Ophthalmic goods and services
-  - Organization and functions (Government agencies)
-  - Over-the-counter drugs
-  - Packaging and containers
-  - Penalties
-  - Prescription drugs
-  - Prisoners
-  - Privacy
-  - Public health
-  - Quarantine
-  - Radiation protection
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Seafood
-  - Signs and symbols
-  - Smoking
-  - Spices and flavorings
-  - Surety bonds
-  - Television
-  - Tobacco
-  - Travel restrictions
-  - Warehouses
-  - Water supply
-  - X-rays
-  - Yogurt
+  - additives
+  - adhesives
+  - advertising
+  - advisory
+  - animal
+  - authority
+  - beverages
+  - biologics
+  - blood
+  - cancer
+  - care
+  - color
+  - committees
+  - communicable
+  - computer
+  - confidential
+  - consumer
+  - containers
+  - cosmetics
+  - courts
+  - cream
+  - delegations
+  - devices
+  - dietary
+  - diseases
+  - drugs
+  - egg
+  - eggs
+  - electronic
+  - exports
+  - feeds
+  - fish
+  - flavorings
+  - food
+  - foods
+  - fruit
+  - fruits
+  - goods
+  - grades
+  - hiv/aids
+  - hospitals
+  - human
+  - immunization
+  - impact
+  - imports
+  - juices
+  - labeling
+  - laboratories
+  - media
+  - medical
+  - milk
+  - news
+  - nutrition
+  - ophthalmic
+  - over-the-counter
+  - packaging
+  - prescription
+  - prisoners
+  - products
+  - quarantine
+  - radiation
+  - restrictions
+  - seafood
+  - services
+  - signs
+  - smoking
+  - spices
+  - standards
+  - statements
+  - subjects
+  - supply
+  - surety
+  - symbols
+  - television
+  - tobacco
+  - travel
+  - warehouses
+  - x-rays
+  - yogurt
   misc:
     ? 'Director, Division of Freedom of Information
 
@@ -1093,37 +1069,29 @@ departments:
     phone:
     - 301-443-3376
   keywords:
-  - Administrative practice and procedure
-  - Aged
-  - Biologics
-  - Claims
-  - Communicable diseases
-  - Courts
-  - Dental health
-  - Drugs
-  - Educational facilities
-  - Educational study programs
-  - Fraud
-  - Grant programs-education
-  - Grant programs-health
-  - HIV/AIDS
-  - Health
-  - Health care
-  - Health facilities
-  - Health insurance
-  - Health professions
-  - Hospitals
-  - Immunization
-  - Insurance companies
-  - Loan programs
-  - Maternal and child health
-  - Medical and dental schools
-  - Medical devices
-  - Public health
-  - Reporting and recordkeeping requirements
-  - Scholarships and fellowships
-  - Smallpox
-  - Student aid
+  - aid
+  - biologics
+  - care
+  - child
+  - communicable
+  - companies
+  - courts
+  - dental
+  - devices
+  - diseases
+  - drugs
+  - fellowships
+  - fraud
+  - hiv/aids
+  - hospitals
+  - immunization
+  - maternal
+  - medical
+  - programs-education
+  - scholarships
+  - smallpox
+  - student
+  - study
   name: Health Resources and Services Administration
   phone: 301-443-3376
   public_liaison:
@@ -1225,19 +1193,11 @@ departments:
     phone:
     - 301-443-1116
   keywords:
-  - Administrative practice and procedure
-  - Buildings and facilities
-  - Claims
-  - Government contracts
-  - Government property management
-  - Grant programs-Indians
-  - Health
-  - Health care
-  - Health facilities
-  - Indians
-  - Indians-business and finance
-  - Medicare
-  - Reporting and recordkeeping requirements
+  - care
+  - finance
+  - indians-business
+  - medicare
+  - programs-indians
   name: Indian Health Service
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1349,13 +1309,11 @@ departments:
     phone:
     - 301-496-5633
   keywords:
-  - Animal welfare
-  - Education of disadvantaged
-  - Government contracts
-  - Grant programs-health
-  - Health professions
-  - Medical research
-  - Occupational safety and health
+  - animal
+  - disadvantaged
+  - medical
+  - occupational
+  - welfare
   name: National Institutes of Health
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1500,20 +1458,15 @@ departments:
     phone:
     - 240-276-2137
   keywords:
-  - Administrative practice and procedure
-  - Alcohol abuse
-  - Alcoholism
-  - Disaster assistance
-  - Drug abuse
-  - Emergency medical services
-  - Grant programs-health
-  - Health facilities
-  - Health professions
-  - Health records
-  - Mental health programs
-  - Methadone
-  - Privacy
-  - Reporting and recordkeeping requirements
+  - abuse
+  - alcohol
+  - alcoholism
+  - disaster
+  - emergency
+  - medical
+  - mental
+  - methadone
+  - services
   name: Substance Abuse and Mental Health Services Administration
   phone: 240-276-2137
   public_liaison:
@@ -1604,256 +1557,259 @@ departments:
 description: The Department of Health and Human Services protects the health of all
   Americans and provides essential human services.
 keywords:
-- Accounting
-- Adhesives
-- Administrative practice and procedure
-- Adoption and foster care
-- Adult education
-- Advertising
-- Advisory committees
-- Aged
-- Agriculture
-- Aid to Families with Dependent Children
-- Airports
-- Alcohol abuse
-- Alcoholism
-- Aliens
-- American Samoa
-- Animal drugs
-- Animal feeds
-- Animal foods
-- Animal welfare
-- Animals
-- Archives and records
-- Authority delegations (Government agencies)
-- Beverages
-- Biologics
-- Black lung benefits
-- Blind
-- Blood
-- Blood diseases
-- Broadband
-- Brokers
-- Buildings and facilities
-- Business and industry
-- Cancer
-- Child support
-- Child welfare
-- Civil rights
-- Claims
-- Coal
-- Colleges and universities
-- Color additives
-- Communicable diseases
-- Communications
-- Community development
-- Computer technology
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Copyright
-- Cosmetics
-- Courts
-- Cream
-- Credit
-- Cuba
-- Cultural exchange programs
-- Day care
-- Dental health
-- Dietary foods
-- Disaster assistance
-- Drug abuse
-- Drugs
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Eggs and egg products
-- Electric power
-- Electric power rates
-- Electric utilities
-- Electronic products
-- Elementary and secondary education
-- Emergency medical services
-- Employee benefit plans
-- Employment
-- Environmental impact statements
-- Equal access to justice
-- Equal educational opportunity
-- Ethics
-- Excise taxes
-- Exports
-- Family planning
-- Federally affected areas
-- Fish
-- Food additives
-- Food grades and standards
-- Food labeling
-- Food packaging
-- Foods
-- Foreign relations
-- Fraud
-- Freedom of information
-- Fruit juices
-- Fruits
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Grant programs
-- Grant programs-Indians
-- Grant programs-education
-- Grant programs-health
-- Grant programs-science and technology
-- Grant programs-social programs
-- Guam
-- HIV/AIDS
-- Harbors
-- Hazardous materials transportation
-- Hazardous substances
-- Health
-- Health care
-- Health facilities
-- Health insurance
-- Health maintenance organizations (HMO)
-- Health professions
-- Health records
-- Health statistics
-- Home improvement
-- Homeless
-- Hospice care
-- Hospitals
-- Hostages
-- Human research subjects
-- Immigration
-- Immunization
-- Imports
-- Indemnity payments
-- Indians
-- Indians-business and finance
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Insurance companies
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kidney diseases
-- Kuwait
-- Labeling
-- Labor
-- Laboratories
-- Law enforcement
-- Lebanon
-- Libraries
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-health
-- Loan programs-housing and community development
-- Loan programs-social programs
-- Lung diseases
-- Manpower training programs
-- Maternal and child health
-- Medicaid
-- Medical and dental schools
-- Medical devices
-- Medical research
-- Medicare
-- Mental health programs
-- Methadone
-- Migrant labor
-- Milk
-- Mine safety and health
-- Miners
-- Mortgage insurance
-- Mortgages
-- News media
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nuclear materials
-- Nursing homes
-- Nutrition
-- Occupational safety and health
-- Ophthalmic goods and services
-- Organization and functions (Government agencies)
-- Over-the-counter drugs
-- Pacific Islands Trust Territory
-- Packaging and containers
-- Passports and visas
-- Penalties
-- Prescription drugs
-- Prisoners
-- Privacy
-- Private schools
-- Public assistance programs
-- Public health
-- Puerto Rico
-- Quarantine
-- Radiation protection
-- Radioactive materials
-- Real property acquisition
-- Refugees
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Scientists
-- Seafood
-- Seals and insignia
-- Securities
-- Sex discrimination
-- Signs and symbols
-- Small businesses
-- Smallpox
-- Smoking
-- Social security
-- Spices and flavorings
-- State and local governments
-- Student aid
-- Students
-- Sunshine Act
-- Supplemental Security Income (SSI)
-- Surety bonds
-- Taxes
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Television
-- Tobacco
-- Transportation
-- Travel restrictions
-- Unemployment compensation
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Warehouses
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Whistleblowing
-- Women
-- Workers' compensation
-- X-rays
-- Yogurt
-- Youth
+- abuse
+- access
+- acquisition
+- act
+- additives
+- adhesives
+- adoption
+- adult
+- advertising
+- advisory
+- affected
+- aid
+- airports
+- alcohol
+- alcoholism
+- aliens
+- american
+- animal
+- animals
+- archives
+- assistance
+- authority
+- benefit
+- benefits
+- beverages
+- biologics
+- black
+- blind
+- blood
+- broadband
+- brokers
+- businesses
+- cancer
+- care
+- child
+- children
+- coal
+- colleges
+- color
+- committees
+- communicable
+- companies
+- compensation
+- computer
+- confidential
+- construction
+- consumer
+- containers
+- copyright
+- cosmetics
+- courts
+- cream
+- cuba
+- cultural
+- day
+- delegations
+- dental
+- dependent
+- devices
+- dietary
+- disadvantaged
+- disaster
+- diseases
+- disposal
+- drugs
+- egg
+- eggs
+- electronic
+- elementary
+- emergency
+- employee
+- ethics
+- exchange
+- excise
+- exports
+- families
+- family
+- federally
+- feeds
+- fellowships
+- finance
+- fish
+- flavorings
+- food
+- foods
+- foster
+- fraud
+- fruit
+- fruits
+- goods
+- governments
+- grades
+- guam
+- harbors
+- hazardous
+- hiv/aids
+- hmo
+- home
+- homeless
+- homes
+- hospice
+- hospitals
+- hostages
+- human
+- immigration
+- immunization
+- impact
+- imports
+- improvement
+- indemnity
+- indians-business
+- indians-education
+- insignia
+- international
+- inventions
+- iraq
+- juices
+- justice
+- kidney
+- kuwait
+- labeling
+- laboratories
+- lebanon
+- libraries
+- local
+- lung
+- maintenance
+- manpower
+- mariana
+- materials
+- maternal
+- media
+- medicaid
+- medical
+- medicare
+- mental
+- methadone
+- migrant
+- milk
+- mine
+- miners
+- mortgage
+- mortgages
+- news
+- nonprofit
+- northern
+- nuclear
+- nursing
+- nutrition
+- occupational
+- ophthalmic
+- organizations
+- over-the-counter
+- pacific
+- packaging
+- passports
+- patents
+- payments
+- planning
+- plans
+- prescription
+- prisoners
+- private
+- procurement
+- products
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-health
+- programs-indians
+- programs-science
+- programs-social
+- property
+- public
+- puerto
+- quarantine
+- radiation
+- radioactive
+- rates
+- real
+- records
+- refugees
+- rehabilitation
+- religious
+- restrictions
+- rico
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- scientists
+- seafood
+- seals
+- secondary
+- security
+- services
+- sex
+- signs
+- small
+- smallpox
+- smoking
+- social
+- spices
+- ssi
+- standards
+- state
+- statements
+- statistics
+- student
+- students
+- study
+- subjects
+- substances
+- sunshine
+- supplemental
+- supply
+- support
+- surety
+- symbols
+- taxes
+- teachers
+- technical
+- technology
+- telecommunications
+- telephone
+- television
+- territory
+- tobacco
+- training
+- travel
+- treatment
+- trust
+- unemployment
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- visas
+- vocational
+- warehouses
+- waste
+- watersheds
+- welfare
+- whistleblowing
+- women
+- workers'
+- x-rays
+- yogurt
+- youth
 name: Department of Health and Human Services
 request_time_stats:
   '2008':

--- a/contacts/data/HUD.yaml
+++ b/contacts/data/HUD.yaml
@@ -942,167 +942,157 @@ emails:
 - foia_hud.gov
 fax: 202-619-8365
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Advertising
-- Aged
-- Agriculture
-- Alaska
-- American Samoa
-- Archives and records
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Civil rights
-- Claims
-- Classified information
-- Colleges and universities
-- Communications
-- Community development
-- Community development block grants
-- Computer technology
-- Condominiums
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Cooperatives
-- Copyright
-- Courts
-- Credit
-- Crime
-- Cultural exchange programs
-- Drug abuse
-- Drug traffic control
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Electronic products
-- Elementary and secondary education
-- Employment
-- Environmental impact statements
-- Environmental protection
-- Equal access to justice
-- Equal educational opportunity
-- Equal employment opportunity
-- Fair housing
-- Federal Reserve System
-- Federal home loan banks
-- Federally affected areas
-- Fire prevention
-- Flood insurance
-- Fraud
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Grant programs
-- Grant programs-Indians
-- Grant programs-education
-- Grant programs-health
-- Grant programs-housing and community development
-- Grant programs-social programs
-- Guam
-- HIV/AIDS
-- Hawaiian Natives
-- Health facilities
-- Health insurance
-- Health professions
-- Historic preservation
-- Home improvement
-- Homeless
-- Hospitals
-- Housing
-- Housing standards
-- Human research subjects
-- Income taxes
-- Indians
-- Indians-education
-- Indians-lands
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Labor
-- Lawyers
-- Lead poisoning
-- Loan programs
-- Loan programs-Indians
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-health
-- Loan programs-housing and community development
-- Low and moderate income housing
-- Manpower training programs
-- Manufactured homes
-- Mental health programs
-- Migrant labor
-- Minority businesses
-- Mortgage insurance
-- Mortgages
-- National banks
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nursing homes
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Penalties
-- Pets
-- Privacy
-- Private schools
-- Public housing
-- Puerto Rico
-- Religious discrimination
-- Relocation assistance
-- Rent subsidies
-- Reporting and recordkeeping requirements
-- Rural areas
-- Safety
-- Savings associations
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seals and insignia
-- Securities
-- Sex discrimination
-- Small businesses
-- Social security
-- Solar energy
-- State and local governments
-- Student aid
-- Sunshine Act
-- Surety bonds
-- Surplus Government property
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Unemployment compensation
-- Urban areas
-- Utilities
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- access
+- act
+- adult
+- advertising
+- affected
+- aid
+- alaska
+- american
+- archives
+- associations
+- banks
+- blind
+- block
+- broadband
+- businesses
+- classified
+- colleges
+- community
+- compensation
+- computer
+- condominiums
+- confidential
+- construction
+- consumer
+- cooperatives
+- copyright
+- courts
+- crime
+- cultural
+- development
+- disadvantaged
+- disposal
+- drug
+- electronic
+- elementary
+- energy
+- exchange
+- fair
+- federal
+- federally
+- fellowships
+- fire
+- flood
+- fraud
+- governments
+- grants
+- guam
+- hawaiian
+- historic
+- hiv/aids
+- home
+- homeless
+- homes
+- hospitals
+- housing
+- human
+- impact
+- improvement
+- income
+- indians-education
+- indians-lands
+- insignia
+- international
+- inventions
+- justice
+- lawyers
+- lead
+- local
+- low
+- manpower
+- manufactured
+- mariana
+- mental
+- migrant
+- minority
+- moderate
+- mortgage
+- mortgages
+- natives
+- nonprofit
+- northern
+- nursing
+- pacific
+- patents
+- pets
+- poisoning
+- preservation
+- prevention
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-health
+- programs-housing
+- programs-indians
+- programs-social
+- puerto
+- rates
+- rehabilitation
+- religious
+- relocation
+- rent
+- reserve
+- rico
+- rural
+- samoa
+- savings
+- scholarships
+- school
+- schools
+- science
+- seals
+- secondary
+- sex
+- small
+- social
+- solar
+- standards
+- state
+- statements
+- student
+- study
+- subjects
+- subsidies
+- sunshine
+- supply
+- surety
+- surplus
+- system
+- teachers
+- technical
+- technology
+- telecommunications
+- telephone
+- territory
+- traffic
+- training
+- treatment
+- trust
+- unemployment
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- women
 name: Department of Housing and Urban Development
 notes: This office has additional FOIA contact information that can be found by visiting
   its website.

--- a/contacts/data/IAF.yaml
+++ b/contacts/data/IAF.yaml
@@ -101,17 +101,10 @@ description: The Inter-American Foundation provides grant support to Latin Ameri
   and Carribean grass-roots groups and non-governmental organizations with creative
   self-help ideas.
 keywords:
-- Administrative practice and procedure
-- Government employees
-- Grant programs
-- Health facilities
-- Health insurance
-- Health professions
-- Hostages
-- Iraq
-- Kuwait
-- Lebanon
-- Loan programs
+- hostages
+- iraq
+- kuwait
+- lebanon
 name: Inter-American Foundation
 request_time_stats:
   '2008':

--- a/contacts/data/LSC.yaml
+++ b/contacts/data/LSC.yaml
@@ -68,17 +68,13 @@ description: The Legal Services Corporation is an independent corporation founde
   legal aid programs. The goal of the corporation is to ensure low income individuals
   and families have access to quality legal aid in civil matters.
 keywords:
-- Administrative practice and procedure
-- Aliens
-- Civil rights
-- Crime
-- Freedom of information
-- Grant programs-law
-- Individuals with disabilities
-- Lawyers
-- Legal services
-- Migrant labor
-- Reporting and recordkeeping requirements
+- aliens
+- crime
+- lawyers
+- legal
+- migrant
+- programs-law
+- services
 name: Legal Services Corporation
 request_time_stats:
   '2010':

--- a/contacts/data/MCC.yaml
+++ b/contacts/data/MCC.yaml
@@ -81,10 +81,7 @@ description: The Millenium Challenge Corporation is an independent foreign aid a
   on a competitive basis, and projects funded by the corporation are chosen and managed
   by the recipient country.
 keywords:
-- Administrative practice and procedure
-- Courts
-- Government employees
-- Organization and functions (Government agencies)
+- courts
 name: Millennium Challenge Corporation
 request_time_stats:
   '2010':

--- a/contacts/data/MSPB.yaml
+++ b/contacts/data/MSPB.yaml
@@ -278,16 +278,10 @@ emails:
 - foiahq@mspb.gov
 fax: 202-653-7130
 keywords:
-- Administrative practice and procedure
-- Civil rights
-- Confidential business information
-- Conflict of interests
-- Freedom of information
-- Government employees
-- Lawyers
-- Privacy
-- Veterans
-- Whistleblowing
+- confidential
+- lawyers
+- veterans
+- whistleblowing
 name: Merit Systems Protection Board
 phone: 202-653-7200
 public_liaison:

--- a/contacts/data/NARA.yaml
+++ b/contacts/data/NARA.yaml
@@ -383,117 +383,99 @@ emails:
 - foia@nara.gov
 fax: 301-837-0293
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- American Samoa
-- Archives and records
-- Authority delegations (Government agencies)
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Civil defense
-- Civil rights
-- Claims
-- Classified information
-- Colleges and universities
-- Communications
-- Community development
-- Computer technology
-- Confidential business information
-- Copyright
-- Credit
-- Cultural exchange programs
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Equal employment opportunity
-- Executive orders
-- Federal buildings and facilities
-- Federally affected areas
-- Freedom of information
-- Government contracts
-- Government employees
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Micrographics
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- National defense
-- Nonprofit organizations
-- Northern Mariana Islands
-- Pacific Islands Trust Territory
-- Presidential documents
-- Privacy
-- Private schools
-- Reporting and recordkeeping requirements
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seals and insignia
-- Securities
-- Security measures
-- Sex discrimination
-- State and local governments
-- Student aid
-- Teachers
-- Telecommunications
-- Telephone
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- adult
+- affected
+- aid
+- american
+- archives
+- authority
+- blind
+- broadband
+- classified
+- colleges
+- computer
+- confidential
+- construction
+- copyright
+- cultural
+- defense
+- delegations
+- disadvantaged
+- disposal
+- documents
+- elementary
+- exchange
+- executive
+- federally
+- fellowships
+- governments
+- guam
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- improvement
+- indians-education
+- insignia
+- international
+- inventions
+- iraq
+- kuwait
+- lebanon
+- local
+- manpower
+- mariana
+- measures
+- micrographics
+- migrant
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- orders
+- pacific
+- patents
+- presidential
+- private
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-social
+- rates
+- rehabilitation
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seals
+- secondary
+- sex
+- state
+- student
+- study
+- subjects
+- supply
+- teachers
+- technology
+- telecommunications
+- telephone
+- territory
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- women
 name: National Archives and Records Administration
 phone: 301-837-3642
 public_liaison:

--- a/contacts/data/NASA.yaml
+++ b/contacts/data/NASA.yaml
@@ -1224,133 +1224,116 @@ departments:
 description: NASA explores, and conducts scientific research on, Earth systems, the
   solar system, and the universe.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Airports
-- American Samoa
-- Animal welfare
-- Armed forces
-- Authority delegations (Government agencies)
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Civil rights
-- Claims
-- Classified information
-- Colleges and universities
-- Communications
-- Community development
-- Conflict of interests
-- Copyright
-- Credit
-- Cultural exchange programs
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Engineers
-- Environmental impact statements
-- Equal educational opportunity
-- Equal employment opportunity
-- Federal buildings and facilities
-- Federally affected areas
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-science and technology
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Labor management relations
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Mass transportation
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- National defense
-- News media
-- Nonprofit organizations
-- Northern Mariana Islands
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Privacy
-- Private schools
-- Railroads
-- Real property acquisition
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Safety
-- Satellites
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Scientists
-- Securities
-- Security measures
-- Sex discrimination
-- Small businesses
-- Space transportation and exploration
-- State and local governments
-- Student aid
-- Teachers
-- Telecommunications
-- Telephone
-- Urban areas
-- Utilities
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- acquisition
+- adult
+- affected
+- aid
+- airports
+- american
+- animal
+- armed
+- authority
+- blind
+- broadband
+- businesses
+- classified
+- colleges
+- construction
+- copyright
+- cultural
+- defense
+- delegations
+- disadvantaged
+- disposal
+- elementary
+- engineers
+- exchange
+- exploration
+- federally
+- fellowships
+- forces
+- governments
+- guam
+- highways
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- impact
+- improvement
+- indians-education
+- international
+- inventions
+- iraq
+- kuwait
+- lebanon
+- local
+- management
+- manpower
+- mariana
+- mass
+- measures
+- media
+- migrant
+- mortgage
+- mortgages
+- news
+- nonprofit
+- northern
+- pacific
+- patents
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-science
+- programs-social
+- property
+- railroads
+- rates
+- real
+- rehabilitation
+- religious
+- roads
+- rural
+- samoa
+- satellites
+- scholarships
+- school
+- schools
+- science
+- scientists
+- secondary
+- sex
+- small
+- space
+- state
+- statements
+- student
+- study
+- subjects
+- supply
+- teachers
+- technology
+- telecommunications
+- telephone
+- territory
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- welfare
+- women
 name: National Aeronautics and Space Administration
 request_time_stats:
   '2008':

--- a/contacts/data/NCPC.yaml
+++ b/contacts/data/NCPC.yaml
@@ -75,8 +75,7 @@ description: The National Capital Planning Commission crafts long-range plans an
   policies for the National Capital Region. The Commission provides building and zoning
   advice to Washington DC and the surrounding area, and approves various federal construction
   plans.
-keywords:
-- Freedom of information
+keywords: []
 name: National Capital Planning Commission
 request_time_stats:
   '2010':

--- a/contacts/data/NCUA.yaml
+++ b/contacts/data/NCUA.yaml
@@ -56,74 +56,65 @@ description: NCUA is the federal agency that charters and supervises federal cre
   unions and insures savings in federal and most state-chartered credit unions across
   the country through the National Credit Union Share Insurance Fund.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Advertising
-- Aged
-- Agriculture
-- Antitrust
-- Archives and records
-- Authority delegations (Government agencies)
-- Bank deposit insurance
-- Bonds
-- Brokers
-- Civil rights
-- Claims
-- Community development
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Credit
-- Credit unions
-- Crime
-- Currency
-- Equal access to justice
-- Exports
-- Fair housing
-- Federal Reserve System
-- Flood insurance
-- Foreign banking
-- Foreign currencies
-- Foreign trade
-- Freedom of information
-- Gambling
-- Government employees
-- Holding companies
-- Indemnity payments
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- Investigations
-- Investment companies
-- Investments
-- Law enforcement
-- Lawyers
-- Loan programs-business
-- Loan programs-housing and community development
-- Marital status discrimination
-- Mortgages
-- National banks
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Rural areas
-- Savings associations
-- Securities
-- Security measures
-- Sex discrimination
-- Signs and symbols
-- Sunshine Act
-- Surety bonds
-- Technical assistance
-- Trade practices
-- Travel and transportation expenses
-- Travel restrictions
-- Trusts and trustees
-- Truth in lending
-- Truth in savings
-- Wages
+- access
+- act
+- advertising
+- antitrust
+- archives
+- associations
+- authority
+- bank
+- banking
+- banks
+- bonds
+- brokers
+- companies
+- confidential
+- consumer
+- credit
+- crime
+- currencies
+- currency
+- delegations
+- deposit
+- discrimination
+- expenses
+- exports
+- fair
+- flood
+- gambling
+- holding
+- indemnity
+- investment
+- investments
+- justice
+- lawyers
+- lending
+- marital
+- measures
+- mortgages
+- payments
+- practices
+- programs-business
+- religious
+- reserve
+- restrictions
+- rural
+- savings
+- sex
+- signs
+- status
+- sunshine
+- surety
+- symbols
+- system
+- technical
+- trade
+- travel
+- trustees
+- trusts
+- truth
+- unions
 name: National Credit Union Administration
 request_time_stats:
   '2008':

--- a/contacts/data/NIGC.yaml
+++ b/contacts/data/NIGC.yaml
@@ -111,20 +111,11 @@ departments:
 description: The National Indian Gaming Commission is a regulatory body that oversees
   some aspects of gaming on Indian lands, often complementing the work of Indian regulators.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Claims
-- Freedom of information
-- Gambling
-- Government employees
-- Income taxes
-- Indians
-- Indians-business and finance
-- Indians-lands
-- Indians-tribal government
-- Privacy
-- Reporting and recordkeeping requirements
-- Wages
+- finance
+- gambling
+- indians-business
+- indians-lands
+- indians-tribal
 name: National Indian Gaming Commission
 request_time_stats:
   '2008':

--- a/contacts/data/NLRB.yaml
+++ b/contacts/data/NLRB.yaml
@@ -85,12 +85,7 @@ description: 'The National Labor Relations Board enforces the National Labor Rel
   Act by: investigating allegations of wrong-doing brought by workers, unions, or
   employers; conducting elections; and deciding and resolving cases.'
 keywords:
-- Administrative practice and procedure
-- Freedom of information
-- Labor management relations
-- Labor unions
-- Privacy
-- Reporting and recordkeeping requirements
+- unions
 name: National Labor Relations Board
 request_time_stats:
   '2010':

--- a/contacts/data/NMB.yaml
+++ b/contacts/data/NMB.yaml
@@ -105,11 +105,8 @@ departments:
 description: The National Mediation Board facilitates the resolution of labor-management
   disputes in the rail and airline industries.
 keywords:
-- Administrative practice and procedure
-- Air carriers
-- Labor management relations
-- Labor unions
-- Railroads
+- railroads
+- unions
 name: National Mediation Board
 request_time_stats:
   '2008':

--- a/contacts/data/NSF.yaml
+++ b/contacts/data/NSF.yaml
@@ -34,124 +34,102 @@ departments:
 description: The National Science Foundation supports research and education across
   all fields of science and technology, primarily through grants.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Airports
-- American Samoa
-- Antarctica
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Civil rights
-- Claims
-- Colleges and universities
-- Communications
-- Community development
-- Conflict of interests
-- Copyright
-- Credit
-- Cultural exchange programs
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Equal employment opportunity
-- Exports
-- Federal buildings and facilities
-- Federally affected areas
-- Fraud
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-science and technology
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Imports
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Mass transportation
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Oil pollution
-- Pacific Islands Trust Territory
-- Penalties
-- Plants
-- Privacy
-- Private schools
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Securities
-- Sex discrimination
-- Small businesses
-- State and local governments
-- Student aid
-- Teachers
-- Telecommunications
-- Telephone
-- Urban areas
-- Vessels
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Wildlife
-- Women
+- adult
+- affected
+- aid
+- airports
+- american
+- antarctica
+- blind
+- broadband
+- businesses
+- colleges
+- construction
+- copyright
+- cultural
+- disadvantaged
+- disposal
+- elementary
+- exchange
+- exports
+- federally
+- fellowships
+- fraud
+- governments
+- guam
+- highways
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- imports
+- improvement
+- indians-education
+- international
+- inventions
+- iraq
+- kuwait
+- lebanon
+- local
+- manpower
+- mariana
+- mass
+- migrant
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- oil
+- pacific
+- patents
+- plants
+- pollution
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-science
+- programs-social
+- railroads
+- rates
+- rehabilitation
+- religious
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- secondary
+- sex
+- small
+- state
+- student
+- study
+- subjects
+- supply
+- teachers
+- technology
+- telecommunications
+- telephone
+- territory
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- wildlife
+- women
 name: National Science Foundation
 request_time_stats:
   '2008':

--- a/contacts/data/NTSB.yaml
+++ b/contacts/data/NTSB.yaml
@@ -74,23 +74,18 @@ description: The National Transportation Safety Board investigates every civil a
   Based on their investigative findings and special studies, the board makes recommendations
   aimed at preventing future accidents.
 keywords:
-- Administrative practice and procedure
-- Airmen
-- Archives and records
-- Aviation safety
-- Claims
-- Equal access to justice
-- Freedom of information
-- Government employees
-- Hazardous materials transportation
-- Highway safety
-- Investigations
-- Lawyers
-- Marine safety
-- Pipeline safety
-- Privacy
-- Railroad safety
-- Reporting and recordkeeping requirements
+- access
+- airmen
+- archives
+- aviation
+- hazardous
+- highway
+- justice
+- lawyers
+- marine
+- materials
+- pipeline
+- railroad
 name: National Transportation Safety Board
 request_time_stats:
   '2010':

--- a/contacts/data/OGE.yaml
+++ b/contacts/data/OGE.yaml
@@ -99,19 +99,11 @@ departments:
 description: The Office of Government Ethics provides oversight, policy, and guidance
   to the Executive Branch regarding ethics laws and policies.
 keywords:
-- Administrative practice and procedure
-- Archives and records
-- Confidential business information
-- Conflict of interests
-- Courts
-- Freedom of information
-- Government employees
-- Government property
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Reporting and recordkeeping requirements
-- Trusts and trustees
+- archives
+- confidential
+- courts
+- trustees
+- trusts
 name: Office of Government Ethics
 request_time_stats:
   '2008':

--- a/contacts/data/OMB.yaml
+++ b/contacts/data/OMB.yaml
@@ -93,96 +93,82 @@ departments:
 description: The Office of Management and Budget oversees the performance of federal
   agencies, and administers the federal budget.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Air carriers
-- American Samoa
-- Blind
-- Broadband
-- Business and industry
-- Civil rights
-- Colleges and universities
-- Communications
-- Community development
-- Copyright
-- Credit
-- Cultural exchange programs
-- Disaster assistance
-- Drug abuse
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Federally affected areas
-- Government contracts
-- Government employees
-- Government procurement
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Home improvement
-- Homeless
-- Hospitals
-- Human research subjects
-- Indians
-- Indians-education
-- Indians-tribal government
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Loan programs-transportation
-- Manpower training programs
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Pacific Islands Trust Territory
-- Penalties
-- Privacy
-- Private schools
-- Reporting and recordkeeping requirements
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Securities
-- State and local governments
-- Student aid
-- Teachers
-- Telecommunications
-- Telephone
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- adult
+- affected
+- aid
+- american
+- blind
+- broadband
+- colleges
+- construction
+- copyright
+- cultural
+- disadvantaged
+- disaster
+- disposal
+- elementary
+- exchange
+- federally
+- fellowships
+- governments
+- guam
+- home
+- homeless
+- hospitals
+- human
+- improvement
+- indians-education
+- indians-tribal
+- international
+- inventions
+- local
+- manpower
+- mariana
+- migrant
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- pacific
+- patents
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-social
+- programs-transportation
+- rates
+- rehabilitation
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- secondary
+- state
+- student
+- study
+- subjects
+- supply
+- teachers
+- telecommunications
+- telephone
+- territory
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- women
 name: Office of Management and Budget
 request_time_stats:
   '2008':

--- a/contacts/data/ONDCP.yaml
+++ b/contacts/data/ONDCP.yaml
@@ -51,96 +51,82 @@ departments:
 description: The Office of National Drug Control Policy coordinates drug-control efforts
   and funding, and advises the president on drug-control issues.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- American Samoa
-- Blind
-- Broadband
-- Business and industry
-- Civil rights
-- Colleges and universities
-- Communications
-- Community development
-- Copyright
-- Credit
-- Cultural exchange programs
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Federally affected areas
-- Government contracts
-- Government employees
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Indians
-- Indians-education
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Iraq
-- Kuwait
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Pacific Islands Trust Territory
-- Privacy
-- Private schools
-- Reporting and recordkeeping requirements
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Securities
-- State and local governments
-- Student aid
-- Teachers
-- Telecommunications
-- Telephone
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- adult
+- affected
+- aid
+- american
+- blind
+- broadband
+- colleges
+- construction
+- copyright
+- cultural
+- disadvantaged
+- disposal
+- elementary
+- exchange
+- federally
+- fellowships
+- governments
+- guam
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- improvement
+- indians-education
+- international
+- inventions
+- iraq
+- kuwait
+- lebanon
+- local
+- manpower
+- mariana
+- migrant
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- pacific
+- patents
+- private
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-social
+- rates
+- rehabilitation
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- secondary
+- state
+- student
+- study
+- subjects
+- supply
+- teachers
+- telecommunications
+- telephone
+- territory
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- women
 name: Office of National Drug Control Policy
 request_time_stats:
   '2008':

--- a/contacts/data/OPIC.yaml
+++ b/contacts/data/OPIC.yaml
@@ -102,12 +102,8 @@ departments:
 description: The Overseas Private Investment Corporation works with the U.S. private
   sector to help solve critical world challenges.
 keywords:
-- Administrative practice and procedure
-- Confidential business information
-- Courts
-- Freedom of information
-- Government employees
-- Privacy
+- confidential
+- courts
 name: Overseas Private Investment Corporation
 request_time_stats:
   '2008':

--- a/contacts/data/OPM.yaml
+++ b/contacts/data/OPM.yaml
@@ -106,96 +106,86 @@ description: OPM manages the civil service of the federal government, coordinate
   benefits programs. OPM also provides resources for locating student jobs, summer
   jobs, scholarships, and internships.
 keywords:
-- Administrative practice and procedure
-- Advertising
-- Aged
-- Air traffic controllers
-- Alcohol abuse
-- Alcoholism
-- Alimony
-- Archives and records
-- Armed forces reserves
-- Authority delegations (Government agencies)
-- Blind
-- Cemeteries
-- Charitable contributions
-- Child support
-- Civil defense
-- Civil rights
-- Claims
-- Colleges and universities
-- Computer technology
-- Conflict of interests
-- Courts
-- Crime
-- Day care
-- Disability benefits
-- District of Columbia
-- Drug abuse
-- Education
-- Employee benefit plans
-- Employment
-- Employment taxes
-- Equal employment opportunity
-- Firefighters
-- Flags
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government publications
-- Grant programs
-- Health
-- Health facilities
-- Health insurance
-- Health professions
-- Health records
-- Holidays
-- Hospitals
-- Hostages
-- Income taxes
-- Indians
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Labor management relations
-- Labor unions
-- Law enforcement officers
-- Lawyers
-- Lebanon
-- Life insurance
-- Loan programs
-- Medicaid
-- Military personnel
-- Motor vehicles
-- National defense
-- Nonprofit organizations
-- Organization and functions (Government agencies)
-- Parking
-- Penalties
-- Political activities (Government employees)
-- Privacy
-- Railroad retirement
-- Railroad unemployment insurance
-- Reporting and recordkeeping requirements
-- Retirement
-- Seals and insignia
-- Security measures
-- Selective Service System
-- Social security
-- Students
-- Supplemental Security Income (SSI)
-- Taxes
-- Travel and transportation expenses
-- Treaties
-- Veterans
-- Vocational rehabilitation
-- Wages
+- abuse
+- activities
+- advertising
+- alcohol
+- alcoholism
+- alimony
+- archives
+- armed
+- authority
+- benefit
+- benefits
+- blind
+- care
+- cemeteries
+- charitable
+- child
+- colleges
+- columbia
+- computer
+- contributions
+- controllers
+- courts
+- crime
+- day
+- defense
+- delegations
+- disability
+- district
+- employee
+- expenses
+- firefighters
+- flags
+- forces
+- holidays
+- hospitals
+- hostages
+- income
+- insignia
+- inventions
+- iraq
+- kuwait
+- lawyers
+- lebanon
+- life
+- measures
+- medicaid
+- military
+- nonprofit
+- officers
+- parking
+- patents
+- personnel
+- plans
+- political
+- procurement
+- publications
+- railroad
+- records
+- rehabilitation
+- reserves
+- retirement
+- seals
+- security
+- selective
+- service
+- social
+- ssi
+- students
+- supplemental
+- support
+- system
+- taxes
+- traffic
+- travel
+- treaties
+- unemployment
+- unions
+- universities
+- vehicles
+- veterans
 name: Office of Personnel Management
 request_time_stats:
   '2008':

--- a/contacts/data/OSC.yaml
+++ b/contacts/data/OSC.yaml
@@ -82,17 +82,9 @@ description: The Office of Special Counsel is an investigative and prosecutorial
   that works to end government and political corruption, and to protect government
   employees and whistleblowers.
 keywords:
-- Administrative practice and procedure
-- Civil rights
-- Freedom of information
-- Government employees
-- Individuals with disabilities
-- Investigations
-- Law enforcement
-- Political activities (Government employees)
-- Privacy
-- Reporting and recordkeeping requirements
-- Whistleblowing
+- activities
+- political
+- whistleblowing
 name: Office of Special Counsel
 request_time_stats:
   '2010':

--- a/contacts/data/OSHRC.yaml
+++ b/contacts/data/OSHRC.yaml
@@ -107,18 +107,11 @@ description: The Occupational Safety and Health Review Commission hears trials a
   appeals, deciding contests of citations or penalties that result from inspections
   performed by the Occupational Safety and Health Administration.
 keywords:
-- Administrative practice and procedure
-- Archives and records
-- Civil rights
-- Conflict of interests
-- Equal access to justice
-- Equal employment opportunity
-- Federal buildings and facilities
-- Freedom of information
-- Government employees
-- Individuals with disabilities
-- Privacy
-- Sunshine Act
+- access
+- act
+- archives
+- justice
+- sunshine
 name: Occupational Safety and Health Review Commission
 request_time_stats:
   '2008':

--- a/contacts/data/OSTP.yaml
+++ b/contacts/data/OSTP.yaml
@@ -113,9 +113,10 @@ description: The Office of Science and Technology Policy advises the president o
   the effects of science and technology on domestic and international affairs. It
   also develops, coordinates, and implements science and technology policies and budgets.
 keywords:
-- Classified information
+- classified
 - cto
-- white house
+- house
+- white
 name: Office of Science and Technology Policy
 no_records_about:
 - General White House correspondance or documents.

--- a/contacts/data/PBGC.yaml
+++ b/contacts/data/PBGC.yaml
@@ -84,25 +84,14 @@ description: Funded by the insurance premiums it collects and other investments,
   you are a plan sponsor or administrator, use the contact link below to find the
   appropriate information.
 keywords:
-- Administrative practice and procedure
-- Business and industry
-- Civil rights
-- Claims
-- Conflict of interests
-- Employee benefit plans
-- Equal employment opportunity
-- Federal buildings and facilities
-- Freedom of information
-- Government employees
-- Income taxes
-- Individuals with disabilities
-- Organization and functions (Government agencies)
-- Penalties
-- Pension insurance
-- Political activities (Government employees)
-- Privacy
-- Reporting and recordkeeping requirements
-- Small businesses
+- activities
+- benefit
+- businesses
+- employee
+- pension
+- plans
+- political
+- small
 name: Pension Benefit Guaranty Corporation
 request_time_stats:
   '2010':

--- a/contacts/data/PC.yaml
+++ b/contacts/data/PC.yaml
@@ -136,22 +136,11 @@ description: Peace Corps volunteers travel to developing countries all over the 
   to assist with many ongoing efforts including AIDS education, business training,
   and information infrastructure development.
 keywords:
-- Administrative practice and procedure
-- Claims
-- Freedom of information
-- Government contracts
-- Government employees
-- Grant programs
-- Health facilities
-- Health insurance
-- Health professions
-- Hostages
-- Iraq
-- Kuwait
-- Lebanon
-- Loan programs
-- Reporting and recordkeeping requirements
-- Technical assistance
+- hostages
+- iraq
+- kuwait
+- lebanon
+- technical
 name: Peace Corps
 request_time_stats:
   '2008':

--- a/contacts/data/PRC.yaml
+++ b/contacts/data/PRC.yaml
@@ -114,16 +114,14 @@ description: The Postal Regulatory Commission is responsible for oversight of th
   U.S. Postal Service, including oversight of rates and services, and ensuring the
   Postal Service meets all of its legal requirements.
 keywords:
-- Administrative practice and procedure
-- Confidential business information
-- Freedom of information
-- Organization and functions (Government agencies)
-- Postal Service
-- Privacy
-- Reporting and recordkeeping requirements
-- Seals and insignia
-- Sunshine Act
-- Trademarks
+- act
+- confidential
+- insignia
+- postal
+- seals
+- service
+- sunshine
+- trademarks
 name: Postal Regulatory Commission
 request_time_stats:
   '2008':

--- a/contacts/data/RATB.yaml
+++ b/contacts/data/RATB.yaml
@@ -54,11 +54,7 @@ description: 'The Recovery Accountability and Transparency Board is a non-partis
   non-political agency created by the American Recovery and Reinvestment Act of 2009
   with two main goals: provide unprecedented transparency of Recovery funds, and detect
   and prevent fraud, waste, and mismanagement of Recovery funds.'
-keywords:
-- Administrative practice and procedure
-- Freedom of information
-- Privacy
-- Reporting and recordkeeping requirements
+keywords: []
 name: Recovery Accountability and Transparency Board
 request_time_stats:
   '2011':

--- a/contacts/data/SBA.yaml
+++ b/contacts/data/SBA.yaml
@@ -90,136 +90,116 @@ description: The SBA helps Americans start, build and grow businesses. Through a
   extensive network of field offices and partnerships the SBA aids, counsels, assists
   and protects the interests of small business concerns.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Airports
-- American Samoa
-- Authority delegations (Government agencies)
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Civil rights
-- Claims
-- Colleges and universities
-- Communications
-- Community development
-- Conduct standards
-- Conflict of interests
-- Copyright
-- Credit
-- Cultural exchange programs
-- Disaster assistance
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal access to justice
-- Equal educational opportunity
-- Equal employment opportunity
-- Exports
-- Federal buildings and facilities
-- Federally affected areas
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Government securities
-- Grant programs
-- Grant programs-business
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Hawaiian Natives
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Income taxes
-- Indians
-- Indians-business and finance
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Investment companies
-- Iraq
-- Kuwait
-- Lawyers
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-business
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Loan programs-veterans
-- Manpower training programs
-- Mass transportation
-- Migrant labor
-- Minority businesses
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Penalties
-- Privacy
-- Private schools
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seals and insignia
-- Securities
-- Sex discrimination
-- Small businesses
-- State and local governments
-- Student aid
-- Surety bonds
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Terrorism
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- access
+- adult
+- affected
+- aid
+- airports
+- american
+- authority
+- blind
+- broadband
+- businesses
+- colleges
+- companies
+- conduct
+- construction
+- copyright
+- cultural
+- delegations
+- disadvantaged
+- disaster
+- disposal
+- elementary
+- exchange
+- exports
+- federally
+- fellowships
+- finance
+- governments
+- guam
+- hawaiian
+- highways
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- improvement
+- indians-business
+- indians-education
+- insignia
+- international
+- inventions
+- investment
+- iraq
+- justice
+- kuwait
+- lawyers
+- lebanon
+- local
+- manpower
+- mariana
+- mass
+- migrant
+- minority
+- mortgage
+- mortgages
+- natives
+- nonprofit
+- northern
+- pacific
+- patents
+- private
+- procurement
+- programs-agriculture
+- programs-business
+- programs-communications
+- programs-education
+- programs-energy
+- programs-social
+- programs-veterans
+- railroads
+- rates
+- rehabilitation
+- religious
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seals
+- secondary
+- securities
+- sex
+- small
+- standards
+- state
+- student
+- study
+- subjects
+- supply
+- surety
+- teachers
+- technical
+- telecommunications
+- telephone
+- territory
+- terrorism
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- women
 name: Small Business Administration
 request_time_stats:
   '2008':

--- a/contacts/data/SEC.yaml
+++ b/contacts/data/SEC.yaml
@@ -83,58 +83,53 @@ description: The Securities and Exchange Commission oversees securities exchange
   to promote fair dealing, the disclosure of important market information, and to
   prevent fraud.
 keywords:
-- Accountants
-- Accounting
-- Administrative practice and procedure
-- Advertising
-- Authority delegations (Government agencies)
-- Brokers
-- Claims
-- Classified information
-- Commodity futures
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Credit
-- Credit unions
-- Currency
-- Electric utilities
-- Electronic funds transfers
-- Environmental impact statements
-- Equal access to justice
-- Equal employment opportunity
-- Foreign banking
-- Foreign currencies
-- Fraud
-- Freedom of information
-- Gambling
-- Government employees
-- Government securities
-- Holding companies
-- Income taxes
-- Insurance
-- Insurance companies
-- Investigations
-- Investment companies
-- Investments
-- Law enforcement
-- Lawyers
-- Life insurance
-- Mortgages
-- National banks
-- Natural gas
-- Organization and functions (Government agencies)
-- Penalties
-- Privacy
-- Reporting and recordkeeping requirements
-- Savings associations
-- Securities
-- Security measures
-- Small businesses
-- Trade practices
-- Trusts and trustees
-- Uniform System of Accounts
-- Wages
+- access
+- accountants
+- accounts
+- advertising
+- associations
+- authority
+- banking
+- banks
+- brokers
+- businesses
+- classified
+- commodity
+- companies
+- confidential
+- consumer
+- credit
+- currencies
+- currency
+- delegations
+- electronic
+- fraud
+- funds
+- futures
+- gambling
+- gas
+- holding
+- impact
+- investment
+- investments
+- justice
+- lawyers
+- life
+- measures
+- mortgages
+- natural
+- practices
+- savings
+- securities
+- small
+- statements
+- system
+- transfers
+- trustees
+- trusts
+- uniform
+- unions
+- utilities
 name: Securities and Exchange Commission
 request_time_stats:
   '2008':

--- a/contacts/data/SIGAR.yaml
+++ b/contacts/data/SIGAR.yaml
@@ -59,12 +59,7 @@ description: The Office of the Special Inspector General for Afghanistan Reconst
   Reconstruction. SIGAR conducts audits and investigations to both promote efficiency
   and effectiveness of reconstruction programs, and to detect and prevent waste, fraud,
   and abuse of taxpayer dollars.
-keywords:
-- Administrative practice and procedure
-- Conflict of interests
-- Freedom of information
-- Government employees
-- Privacy
+keywords: []
 name: Special Inspector General for Afghanistan Reconstruction
 request_time_stats:
   '2011':

--- a/contacts/data/SSA.yaml
+++ b/contacts/data/SSA.yaml
@@ -103,133 +103,120 @@ description: The Social Security Administration assigns social security numbers;
   and administers the Supplemental Security Income program for the aged, blind, and
   disabled.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Air traffic controllers
-- Alcoholism
-- Alimony
-- American Samoa
-- Archives and records
-- Black lung benefits
-- Blind
-- Broadband
-- Business and industry
-- Cemeteries
-- Child support
-- Civil rights
-- Claims
-- Colleges and universities
-- Communications
-- Community development
-- Copyright
-- Courts
-- Credit
-- Crime
-- Cultural exchange programs
-- Disability benefits
-- Drug abuse
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Federally affected areas
-- Firefighters
-- Flags
-- Fraud
-- Freedom of information
-- Government contracts
-- Government employees
-- Government property
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Income taxes
-- Indemnity payments
-- Indians
-- Indians-education
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Law enforcement officers
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Manpower training programs
-- Medicaid
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Parking
-- Penalties
-- Privacy
-- Private schools
-- Public assistance programs
-- Railroad retirement
-- Railroad unemployment insurance
-- Reporting and recordkeeping requirements
-- Retirement
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seals and insignia
-- Securities
-- Security measures
-- Social security
-- State and local governments
-- Student aid
-- Supplemental Security Income (SSI)
-- Teachers
-- Telecommunications
-- Telephone
-- Travel and transportation expenses
-- Treaties
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
-- Workers' compensation
+- adult
+- affected
+- aid
+- alcoholism
+- alimony
+- american
+- archives
+- benefits
+- black
+- blind
+- broadband
+- cemeteries
+- child
+- colleges
+- compensation
+- construction
+- controllers
+- copyright
+- courts
+- crime
+- cultural
+- disability
+- disadvantaged
+- disposal
+- elementary
+- exchange
+- expenses
+- federally
+- fellowships
+- firefighters
+- flags
+- fraud
+- governments
+- guam
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- improvement
+- income
+- indemnity
+- indians-education
+- insignia
+- international
+- inventions
+- iraq
+- kuwait
+- lebanon
+- local
+- lung
+- manpower
+- mariana
+- measures
+- medicaid
+- migrant
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- officers
+- pacific
+- parking
+- patents
+- payments
+- private
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-social
+- railroad
+- rates
+- rehabilitation
+- retirement
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seals
+- secondary
+- security
+- social
+- ssi
+- state
+- student
+- study
+- subjects
+- supplemental
+- supply
+- support
+- teachers
+- telecommunications
+- telephone
+- territory
+- traffic
+- training
+- travel
+- treaties
+- treatment
+- trust
+- unemployment
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- women
+- workers'
 name: Social Security Administration
 request_time_stats:
   '2008':

--- a/contacts/data/SSS.yaml
+++ b/contacts/data/SSS.yaml
@@ -108,9 +108,9 @@ description: The Selective Service System is charged with providing the Departme
   with the Selective Service. The Selective Service also provides alternative service
   options for concientious objectors.
 keywords:
-- Administrative practice and procedure
-- Privacy
-- Selective Service System
+- selective
+- service
+- system
 name: Selective Service System
 request_time_stats:
   '2008':

--- a/contacts/data/State.yaml
+++ b/contacts/data/State.yaml
@@ -193,145 +193,130 @@ description: The Department of State advises the President and leads the nation 
   foreign policy issues. The State Department negotiates treaties and agreements with
   foreign entities, and represents the United States at the United Nations.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adoption and foster care
-- Adult education
-- Aged
-- Agriculture
-- Airports
-- Alien property
-- Aliens
-- American Samoa
-- Arms and munitions
-- Blind
-- Broadband
-- Brokers
-- Buildings and facilities
-- Business and industry
-- Campaign funds
-- Child welfare
-- Civil rights
-- Claims
-- Classified information
-- Colleges and universities
-- Communications
-- Community development
-- Confidential business information
-- Copyright
-- Credit
-- Crime
-- Cultural exchange programs
-- Drug traffic control
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Equal employment opportunity
-- Estates
-- Exports
-- Federal buildings and facilities
-- Federally affected areas
-- Foreign Service
-- Foreign officials
-- Foreign relations
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Immigration
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Labor
-- Law enforcement
-- Law enforcement officers
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Longshore and harbor workers
-- Manpower training programs
-- Mass transportation
-- Mexico
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Pacific Islands Trust Territory
-- Passports and visas
-- Penalties
-- Privacy
-- Private schools
-- Radio
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Retirement
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seamen
-- Securities
-- Seizures and forfeitures
-- Sex discrimination
-- Small businesses
-- State and local governments
-- Student aid
-- Students
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Travel restrictions
-- Treaties
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- adoption
+- adult
+- affected
+- aid
+- airports
+- alien
+- aliens
+- american
+- arms
+- blind
+- broadband
+- brokers
+- businesses
+- campaign
+- care
+- child
+- classified
+- colleges
+- confidential
+- construction
+- copyright
+- crime
+- cultural
+- disadvantaged
+- disposal
+- elementary
+- estates
+- exchange
+- exports
+- federally
+- fellowships
+- forfeitures
+- foster
+- funds
+- governments
+- guam
+- harbor
+- highways
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- immigration
+- improvement
+- indians-education
+- international
+- inventions
+- iraq
+- kuwait
+- lebanon
+- local
+- longshore
+- manpower
+- mariana
+- mass
+- mexico
+- migrant
+- mortgage
+- mortgages
+- munitions
+- nonprofit
+- northern
+- officers
+- officials
+- pacific
+- passports
+- patents
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-social
+- radio
+- railroads
+- rates
+- rehabilitation
+- religious
+- restrictions
+- retirement
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seamen
+- secondary
+- seizures
+- service
+- sex
+- small
+- state
+- student
+- students
+- study
+- subjects
+- supply
+- teachers
+- technical
+- telecommunications
+- telephone
+- territory
+- traffic
+- training
+- travel
+- treaties
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- visas
+- vocational
+- waste
+- watersheds
+- welfare
+- women
+- workers
 name: Department of State
 request_time_stats:
   '2008':

--- a/contacts/data/TVA.yaml
+++ b/contacts/data/TVA.yaml
@@ -105,46 +105,30 @@ description: The Tennessee Valley Authority, a government owned corporation, pro
   low-cost electricity in seven southeatern states and provides flood control, navigation,
   and land management for the Tennessee River system.
 keywords:
-- Administrative practice and procedure
-- Aged
-- Airports
-- Buildings and facilities
-- Civil rights
-- Colleges and universities
-- Education
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Equal educational opportunity
-- Equal employment opportunity
-- Federal buildings and facilities
-- Freedom of information
-- Government property
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-social programs
-- Highways and roads
-- Hunting
-- Individuals with disabilities
-- Investigations
-- Mass transportation
-- Natural resources
-- Navigation (water)
-- Penalties
-- Privacy
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Rivers
-- Sex discrimination
-- Small businesses
-- Student aid
-- Traffic regulations
-- Veterans
-- Water pollution control
-- Women
+- aid
+- airports
+- businesses
+- colleges
+- highways
+- hunting
+- mass
+- natural
+- navigation
+- programs-education
+- programs-social
+- railroads
+- regulations
+- religious
+- rivers
+- roads
+- sex
+- small
+- student
+- study
+- traffic
+- universities
+- veterans
+- women
 name: Tennessee Valley Authority
 request_time_stats:
   '2008':

--- a/contacts/data/Treasury.yaml
+++ b/contacts/data/Treasury.yaml
@@ -10,10 +10,7 @@ departments:
     zip: '20220'
   fax: 202-622-3895
   keywords:
-  - Courts
-  - Freedom of information
-  - Government employees
-  - Privacy
+  - courts
   misc:
     Director, Disclosure Services:
       name: Ryan Law
@@ -50,60 +47,70 @@ departments:
   - ttbfoia@ttb.gov
   fax: 202-453-2331
   keywords:
-  - Administrative practice and procedure
-  - Advertising
-  - Aircraft
-  - Alcohol and alcoholic beverages
-  - Armed forces
-  - Arms and munitions
-  - Authority delegations (Government agencies)
-  - Beer
-  - Caribbean Basin initiative
-  - Chemicals
-  - Cigars and cigarettes
-  - Claims
-  - Consumer protection
-  - Cosmetics
-  - Credit
-  - Customs duties and inspection
-  - Domestic violence
-  - Drugs
-  - Electronic funds transfers
-  - Excise taxes
-  - Explosives
-  - Exports
-  - Food additives
-  - Foreign trade zones
-  - Freedom of information
-  - Fruit juices
-  - Fruits
-  - Gasohol
-  - Health
-  - Imports
-  - Labeling
-  - Law enforcement
-  - Liquors
-  - Military personnel
-  - Packaging and containers
-  - Penalties
-  - Puerto Rico
-  - Reporting and recordkeeping requirements
-  - Research
-  - Safety
-  - Scientific equipment
-  - Security measures
-  - Seizures and forfeitures
-  - Spices and flavorings
-  - Stills
-  - Surety bonds
-  - Tobacco
-  - Trade practices
-  - Transportation
-  - Vessels
-  - Vinegar
-  - Virgin Islands
-  - Warehouses
-  - Wine
+  - additives
+  - advertising
+  - aircraft
+  - alcohol
+  - alcoholic
+  - armed
+  - arms
+  - authority
+  - basin
+  - beer
+  - beverages
+  - caribbean
+  - chemicals
+  - cigarettes
+  - cigars
+  - consumer
+  - containers
+  - cosmetics
+  - customs
+  - delegations
+  - domestic
+  - drugs
+  - duties
+  - electronic
+  - equipment
+  - excise
+  - explosives
+  - exports
+  - flavorings
+  - food
+  - forces
+  - forfeitures
+  - fruit
+  - fruits
+  - funds
+  - gasohol
+  - imports
+  - initiative
+  - inspection
+  - juices
+  - labeling
+  - liquors
+  - measures
+  - military
+  - munitions
+  - packaging
+  - personnel
+  - practices
+  - puerto
+  - rico
+  - scientific
+  - seizures
+  - spices
+  - stills
+  - surety
+  - tobacco
+  - trade
+  - transfers
+  - vinegar
+  - violence
+  - virgin
+  - warehouses
+  - wine
+  - zones
   misc:
     FOIA Contact, Disclosure Services:
       name: Quinton Mason
@@ -137,7 +144,7 @@ departments:
     amounts of currency and coin are in circulation.
   fax: 202-874-2951
   keywords:
-  - Currency
+  - currency
   misc:
     FOIA Contact, FOIA Office:
       name: Disclosure Officer
@@ -173,78 +180,75 @@ departments:
   emails:
   - foia-pa@occ.treas.gov
   keywords:
-  - Accountants
-  - Accounting
-  - Administrative practice and procedure
-  - Advertising
-  - Aged
-  - Agriculture
-  - Antitrust
-  - Authority delegations (Government agencies)
-  - Bank deposit insurance
-  - Brokers
-  - Business and industry
-  - Civil rights
-  - Claims
-  - Community development
-  - Computer technology
-  - Confidential business information
-  - Conflict of interests
-  - Consumer protection
-  - Credit
-  - Credit unions
-  - Crime
-  - Currency
-  - Electronic funds transfers
-  - Equal access to justice
-  - Equal employment opportunity
-  - Estates
-  - Ethics
-  - Exports
-  - Fair housing
-  - Federal Reserve System
-  - Flood insurance
-  - Foreign banking
-  - Foreign currencies
-  - Foreign trade
-  - Freedom of information
-  - Gambling
-  - Government securities
-  - Holding companies
-  - Individuals with disabilities
-  - Insurance
-  - Insurance companies
-  - Investigations
-  - Investment companies
-  - Investments
-  - Law enforcement
-  - Lawyers
-  - Loan programs-housing and community development
-  - Low and moderate income housing
-  - Manufactured homes
-  - Marital status discrimination
-  - Minority businesses
-  - Mortgages
-  - National banks
-  - Nonprofit organizations
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Privacy
-  - Religious discrimination
-  - Reporting and recordkeeping requirements
-  - Rural areas
-  - Savings associations
-  - Securities
-  - Security measures
-  - Sex discrimination
-  - Signs and symbols
-  - Small businesses
-  - Surety bonds
-  - Trade practices
-  - Trusts and trustees
-  - Truth in lending
-  - United States investments abroad
-  - Women
+  - abroad
+  - access
+  - accountants
+  - advertising
+  - antitrust
+  - associations
+  - authority
+  - bank
+  - banking
+  - banks
+  - brokers
+  - businesses
+  - companies
+  - computer
+  - confidential
+  - consumer
+  - credit
+  - crime
+  - currencies
+  - currency
+  - delegations
+  - deposit
+  - discrimination
+  - electronic
+  - estates
+  - ethics
+  - exports
+  - fair
+  - flood
+  - funds
+  - gambling
+  - holding
+  - homes
+  - housing
+  - investment
+  - investments
+  - justice
+  - lawyers
+  - lending
+  - low
+  - manufactured
+  - marital
+  - measures
+  - minority
+  - moderate
+  - mortgages
+  - nonprofit
+  - practices
+  - religious
+  - reserve
+  - rural
+  - savings
+  - securities
+  - sex
+  - signs
+  - small
+  - states
+  - status
+  - surety
+  - symbols
+  - system
+  - trade
+  - transfers
+  - trustees
+  - trusts
+  - truth
+  - unions
+  - united
+  - women
   misc:
     ? 'Disclosures Services
 
@@ -280,21 +284,17 @@ departments:
     authorities.
   fax: 703-905-5126
   keywords:
-  - Administrative practice and procedure
-  - Authority delegations (Government agencies)
-  - Brokers
-  - Currency
-  - Federal home loan banks
-  - Foreign banking
-  - Foreign currencies
-  - Gambling
-  - Investigations
-  - Law enforcement
-  - Mortgages
-  - Penalties
-  - Reporting and recordkeeping requirements
-  - Securities
-  - Terrorism
+  - authority
+  - banking
+  - banks
+  - brokers
+  - currencies
+  - currency
+  - delegations
+  - gambling
+  - home
+  - mortgages
+  - terrorism
   misc:
     Disclosure (FOIA) Office:
       name: Amanda Michanczyk
@@ -326,68 +326,59 @@ departments:
     zip: '20227'
   fax: 202-874-2391
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Aged
-  - Air traffic controllers
-  - Alcoholism
-  - Alimony
-  - Archives and records
-  - Black lung benefits
-  - Blind
-  - Bonds
-  - Cemeteries
-  - Child support
-  - Child welfare
-  - Claims
-  - Courts
-  - Credit
-  - Crime
-  - Disability benefits
-  - Drug abuse
-  - Electronic funds transfers
-  - Federal Reserve System
-  - Firefighters
-  - Flags
-  - Foreign banking
-  - Forgery
-  - Fraud
-  - Freedom of information
-  - Government contracts
-  - Government employees
-  - Government property
-  - Government securities
-  - Grant programs
-  - Housing
-  - Income taxes
-  - Insurance
-  - Insurance companies
-  - Intergovernmental relations
-  - Inventions and patents
-  - Investigations
-  - Law enforcement officers
-  - Loan programs
-  - Medicaid
-  - Parking
-  - Penalties
-  - Privacy
-  - Railroad retirement
-  - Railroad unemployment insurance
-  - Reporting and recordkeeping requirements
-  - Retirement
-  - Seals and insignia
-  - Securities
-  - Security measures
-  - Social security
-  - Supplemental Security Income (SSI)
-  - Surety bonds
-  - Taxes
-  - Travel and transportation expenses
-  - Treaties
-  - Unemployment compensation
-  - Veterans
-  - Vocational rehabilitation
-  - Wages
+  - alcoholism
+  - alimony
+  - archives
+  - banking
+  - benefits
+  - black
+  - blind
+  - bonds
+  - cemeteries
+  - child
+  - companies
+  - compensation
+  - controllers
+  - courts
+  - crime
+  - disability
+  - electronic
+  - expenses
+  - firefighters
+  - flags
+  - forgery
+  - fraud
+  - funds
+  - income
+  - insignia
+  - inventions
+  - lung
+  - measures
+  - medicaid
+  - officers
+  - parking
+  - patents
+  - railroad
+  - rehabilitation
+  - reserve
+  - retirement
+  - seals
+  - securities
+  - security
+  - social
+  - ssi
+  - supplemental
+  - support
+  - surety
+  - system
+  - taxes
+  - traffic
+  - transfers
+  - travel
+  - treaties
+  - unemployment
+  - veterans
+  - welfare
   misc:
     Disclosure Officer:
       name: Cynthia Sydnor/Denise Nelson
@@ -418,71 +409,62 @@ departments:
     tax laws.
   fax: 877-807-9215
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Advertising
-  - Advisory committees
-  - Alimony
-  - Bankruptcy
-  - Biologics
-  - Bonds
-  - Brokers
-  - Campaign funds
-  - Child support
-  - Consumer protection
-  - Continental shelf
-  - Courts
-  - Crime
-  - Drugs
-  - Employee benefit plans
-  - Employment taxes
-  - Estate taxes
-  - Excise taxes
-  - Fishing vessels
-  - Foreign relations
-  - Foundations
-  - Freedom of information
-  - Gambling
-  - Gasoline
-  - Gift taxes
-  - Government employees
-  - Grant programs-health
-  - Health care
-  - Health insurance
-  - Health records
-  - Hospitals
-  - Income taxes
-  - Individuals with disabilities
-  - Insurance
-  - Investigations
-  - Investments
-  - Law enforcement
-  - Loan programs-health
-  - Lobbying
-  - Medicaid
-  - Motor vehicles
-  - Nonprofit organizations
-  - Oil pollution
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Privacy
-  - Public assistance programs
-  - Railroad retirement
-  - Reporting and recordkeeping requirements
-  - Seals and insignia
-  - Securities
-  - Social security
-  - State and local governments
-  - Statistics
-  - Sunshine Act
-  - Taxes
-  - Technical assistance
-  - Telephone
-  - Transportation
-  - Trusts and trustees
-  - Unemployment compensation
-  - Women
-  - Youth
+  - act
+  - advertising
+  - advisory
+  - alimony
+  - bankruptcy
+  - benefit
+  - biologics
+  - brokers
+  - campaign
+  - care
+  - child
+  - committees
+  - compensation
+  - consumer
+  - continental
+  - courts
+  - crime
+  - drugs
+  - employee
+  - estate
+  - excise
+  - fishing
+  - foundations
+  - funds
+  - gambling
+  - gasoline
+  - gift
+  - governments
+  - hospitals
+  - insignia
+  - investments
+  - lobbying
+  - local
+  - medicaid
+  - nonprofit
+  - oil
+  - plans
+  - programs-health
+  - railroad
+  - retirement
+  - seals
+  - shelf
+  - social
+  - state
+  - statistics
+  - sunshine
+  - support
+  - taxes
+  - technical
+  - telephone
+  - trustees
+  - trusts
+  - unemployment
+  - vehicles
+  - women
+  - youth
   misc:
     FOIA Contact:
       name: Disclosure Manager
@@ -571,315 +553,344 @@ description: The Department of the Treasury manages Federal finances by collecti
   taxes and paying bills and by managing currency, government accounts and public
   debt. The Department of the Treasury also enforces finance and tax laws.
 keywords:
-- Accountants
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Advertising
-- Advisory committees
-- Afghanistan
-- Aged
-- Agricultural commodities
-- Agriculture
-- Air carriers
-- Air pollution control
-- Air traffic controllers
-- Air transportation
-- Aircraft
-- Airports
-- Alcohol and alcoholic beverages
-- Alcoholism
-- Aliens
-- Alimony
-- American Samoa
-- Animals
-- Antidumping
-- Antitrust
-- Archives and records
-- Armed forces
-- Arms and munitions
-- Arson
-- Authority delegations (Government agencies)
-- Bank deposit insurance
-- Bankruptcy
-- Beer
-- Biologics
-- Black lung benefits
-- Blind
-- Blocking of assets
-- Bonds
-- Broadband
-- Brokers
-- Buildings and facilities
-- Burma
-- Business and industry
-- Cambodia
-- Campaign funds
-- Canada
-- Cargo vessels
-- Caribbean Basin initiative
-- Cemeteries
-- Chemicals
-- Child support
-- Child welfare
-- Cigars and cigarettes
-- Civil rights
-- Claims
-- Classified information
-- Coastal zone
-- Colleges and universities
-- Commodity futures
-- Common carriers
-- Communications
-- Community development
-- Computer technology
-- Confidential business information
-- Conflict of interests
-- Consumer protection
-- Continental shelf
-- Copyright
-- Cosmetics
-- Countervailing duties
-- Courts
-- Credit
-- Credit unions
-- Crime
-- Cuba
-- Cultural exchange programs
-- Currency
-- Customs duties and inspection
-- Diamonds
-- Disability benefits
-- Disaster assistance
-- Domestic violence
-- Drug abuse
-- Drug traffic control
-- Drugs
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Electronic funds transfers
-- Electronic products
-- Elementary and secondary education
-- Employee benefit plans
-- Employment
-- Employment taxes
-- Equal access to justice
-- Equal educational opportunity
-- Equal employment opportunity
-- Estate taxes
-- Estates
-- Ethics
-- Excise taxes
-- Explosives
-- Exports
-- Fair housing
-- Federal Reserve System
-- Federal home loan banks
-- Federally affected areas
-- Firefighters
-- Fisheries
-- Fishing vessels
-- Flags
-- Flood insurance
-- Food additives
-- Foods
-- Foreign banking
-- Foreign claims
-- Foreign currencies
-- Foreign investments in United States
-- Foreign relations
-- Foreign trade
-- Foreign trade zones
-- Forgery
-- Foundations
-- Fraud
-- Freedom of information
-- Freight
-- Freight forwarders
-- Fruit juices
-- Fruits
-- Furs
-- Gambling
-- Gasohol
-- Gasoline
-- Gift taxes
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government securities
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-housing and community development
-- Grant programs-social programs
-- Guam
-- Harbors
-- Hazardous substances
-- Health
-- Health care
-- Health facilities
-- Health insurance
-- Health professions
-- Health records
-- Holding companies
-- Home improvement
-- Homeless
-- Hospitals
-- Housing
-- Human research subjects
-- Humanitarian aid
-- Immigration
-- Imports
-- Income taxes
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Insurance companies
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Investment companies
-- Investments
-- Iran
-- Iraq
-- Labeling
-- Laboratories
-- Law enforcement
-- Law enforcement officers
-- Lawyers
-- Lebanon
-- Liberia
-- Libya
-- Liquors
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-health
-- Loan programs-housing and community development
-- Lobbying
-- Low and moderate income housing
-- Manpower training programs
-- Manufactured homes
-- Marine resources
-- Marital status discrimination
-- Maritime carriers
-- Medicaid
-- Medical devices
-- Mexico
-- Midway Islands
-- Migrant labor
-- Military personnel
-- Minority businesses
-- Mortgage insurance
-- Mortgages
-- Motor carriers
-- Motor vehicles
-- National banks
-- National defense
-- Natural resources
-- New Investment
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nuclear materials
-- Oil imports
-- Oil pollution
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Packaging and containers
-- Parking
-- Passenger vessels
-- Penalties
-- Petroleum
-- Privacy
-- Private schools
-- Public assistance programs
-- Puerto Rico
-- Railroad retirement
-- Railroad unemployment insurance
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Retirement
-- Rural areas
-- Russian Federation
-- Safety
-- Savings associations
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Scientific equipment
-- Seals and insignia
-- Securities
-- Security measures
-- Seizures and forfeitures
-- Services
-- Sex discrimination
-- Signs and symbols
-- Small businesses
-- Social security
-- Specially Designated Nationals
-- Spices and flavorings
-- State and local governments
-- Statistics
-- Stills
-- Student aid
-- Sudan
-- Sunshine Act
-- Supplemental Security Income (SSI)
-- Surety bonds
-- Taxes
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Terrorism
-- Tobacco
-- Trade agreements
-- Trade practices
-- Trademarks
-- Transportation
-- Travel and transportation expenses
-- Travel restrictions
-- Treaties
-- Trusts and trustees
-- Truth in lending
-- Unemployment compensation
-- United States investments abroad
-- Uranium
-- Urban areas
-- Vessels
-- Veterans
-- Vietnam
-- Vinegar
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Wake Island
-- Warehouses
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Western Balkans
-- Wildlife
-- Wine
-- Women
-- Youth
-- Yugoslavia
+- abroad
+- access
+- accountants
+- act
+- additives
+- adult
+- advertising
+- advisory
+- affected
+- afghanistan
+- agreements
+- agricultural
+- aid
+- air
+- aircraft
+- airports
+- alcohol
+- alcoholic
+- alcoholism
+- aliens
+- alimony
+- american
+- animals
+- antidumping
+- antitrust
+- archives
+- armed
+- arms
+- arson
+- assets
+- assistance
+- associations
+- authority
+- balkans
+- bank
+- banking
+- bankruptcy
+- banks
+- basin
+- beer
+- benefit
+- benefits
+- beverages
+- biologics
+- black
+- blind
+- blocking
+- bonds
+- broadband
+- brokers
+- burma
+- businesses
+- cambodia
+- campaign
+- canada
+- care
+- cargo
+- caribbean
+- carriers
+- cemeteries
+- chemicals
+- child
+- cigarettes
+- cigars
+- classified
+- coastal
+- colleges
+- committees
+- commodities
+- commodity
+- common
+- companies
+- compensation
+- computer
+- confidential
+- construction
+- consumer
+- containers
+- continental
+- control
+- controllers
+- copyright
+- cosmetics
+- countervailing
+- courts
+- credit
+- crime
+- cuba
+- cultural
+- currencies
+- currency
+- customs
+- defense
+- delegations
+- deposit
+- designated
+- devices
+- diamonds
+- disability
+- disadvantaged
+- disaster
+- discrimination
+- disposal
+- domestic
+- drug
+- drugs
+- duties
+- electronic
+- elementary
+- employee
+- equipment
+- estate
+- estates
+- ethics
+- exchange
+- excise
+- expenses
+- explosives
+- exports
+- fair
+- federal
+- federally
+- federation
+- fellowships
+- firefighters
+- fisheries
+- fishing
+- flags
+- flavorings
+- flood
+- food
+- foods
+- forces
+- foreign
+- forfeitures
+- forgery
+- forwarders
+- foundations
+- fraud
+- freight
+- fruit
+- fruits
+- funds
+- furs
+- futures
+- gambling
+- gasohol
+- gasoline
+- gift
+- governments
+- guam
+- harbors
+- hazardous
+- holding
+- home
+- homeless
+- homes
+- hospitals
+- housing
+- human
+- humanitarian
+- immigration
+- imports
+- improvement
+- income
+- indians-education
+- initiative
+- insignia
+- inspection
+- international
+- inventions
+- investment
+- investments
+- iran
+- iraq
+- island
+- juices
+- justice
+- labeling
+- laboratories
+- lawyers
+- lebanon
+- lending
+- liberia
+- libya
+- liquors
+- lobbying
+- local
+- low
+- lung
+- manpower
+- manufactured
+- mariana
+- marine
+- marital
+- maritime
+- materials
+- measures
+- medicaid
+- medical
+- mexico
+- midway
+- migrant
+- military
+- minority
+- moderate
+- mortgage
+- mortgages
+- motor
+- munitions
+- national
+- nationals
+- natural
+- new
+- nonprofit
+- northern
+- nuclear
+- officers
+- oil
+- pacific
+- packaging
+- parking
+- passenger
+- patents
+- personnel
+- petroleum
+- plans
+- pollution
+- practices
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-health
+- programs-housing
+- programs-social
+- puerto
+- railroad
+- railroads
+- rates
+- records
+- rehabilitation
+- religious
+- reserve
+- resources
+- restrictions
+- retirement
+- rico
+- rural
+- russian
+- samoa
+- savings
+- scholarships
+- school
+- schools
+- science
+- scientific
+- seals
+- secondary
+- securities
+- security
+- seizures
+- services
+- sex
+- shelf
+- signs
+- small
+- social
+- specially
+- spices
+- ssi
+- state
+- states
+- statistics
+- status
+- stills
+- student
+- study
+- subjects
+- substances
+- sudan
+- sunshine
+- supplemental
+- supply
+- support
+- surety
+- symbols
+- system
+- taxes
+- teachers
+- technical
+- technology
+- telecommunications
+- telephone
+- territory
+- terrorism
+- tobacco
+- trade
+- trademarks
+- traffic
+- training
+- transfers
+- travel
+- treaties
+- treatment
+- trust
+- trustees
+- trusts
+- truth
+- unemployment
+- unions
+- united
+- universities
+- uranium
+- urban
+- utilities
+- vehicles
+- vessels
+- veterans
+- vietnam
+- vinegar
+- violence
+- virgin
+- vocational
+- wake
+- warehouses
+- waste
+- watersheds
+- welfare
+- western
+- wildlife
+- wine
+- women
+- youth
+- yugoslavia
+- zone
+- zones
 name: Department of the Treasury
 usa_id: '49034'

--- a/contacts/data/U.S. CPSC.yaml
+++ b/contacts/data/U.S. CPSC.yaml
@@ -113,32 +113,34 @@ description: The CPSC protects the public from unreasonable risks of serious inj
   products that pose a fire, electrical, chemical, or mechanical hazard or can injure
   children.
 keywords:
-- Administrative practice and procedure
-- Business and industry
-- Clothing
-- Consumer protection
-- Drugs
-- Fire prevention
-- Flammable materials
-- Hazardous substances
-- Household appliances
-- Human research subjects
-- Imports
-- Investigations
-- Labeling
-- Law enforcement
-- Lead poisoning
-- Mattresses and mattress pads
-- Organization and functions (Government agencies)
-- Packaging and containers
-- Poison prevention
-- Reporting and recordkeeping requirements
-- Research
-- Safety
-- Textiles
-- Toys
-- Voluntary standards
-- Youth
+- appliances
+- clothing
+- consumer
+- containers
+- drugs
+- fire
+- flammable
+- hazardous
+- household
+- human
+- imports
+- labeling
+- lead
+- materials
+- mattress
+- mattresses
+- packaging
+- pads
+- poison
+- poisoning
+- prevention
+- standards
+- subjects
+- substances
+- textiles
+- toys
+- voluntary
+- youth
 name: Consumer Product Safety Commission
 request_time_stats:
   '2008':

--- a/contacts/data/U.S. DOL.yaml
+++ b/contacts/data/U.S. DOL.yaml
@@ -259,40 +259,33 @@ departments:
   emails:
   - foiarequests@dol.gov
   keywords:
-  - Accountants
-  - Accounting
-  - Administrative practice and procedure
-  - Advertising
-  - Advisory committees
-  - Brokers
-  - Claims
-  - Consumer protection
-  - Employee benefit plans
-  - Excise taxes
-  - Government employees
-  - Grant programs-health
-  - Health care
-  - Health insurance
-  - Health records
-  - Hospitals
-  - Individuals with disabilities
-  - Investments
-  - Law enforcement
-  - Loan programs-health
-  - Medicaid
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Public assistance programs
-  - Reporting and recordkeeping requirements
-  - Retirement
-  - Securities
-  - State and local governments
-  - Sunshine Act
-  - Surety bonds
-  - Technical assistance
-  - Trusts and trustees
-  - Women
-  - Youth
+  - accountants
+  - act
+  - advertising
+  - advisory
+  - benefit
+  - brokers
+  - care
+  - committees
+  - consumer
+  - employee
+  - excise
+  - governments
+  - hospitals
+  - investments
+  - local
+  - medicaid
+  - plans
+  - programs-health
+  - retirement
+  - state
+  - sunshine
+  - surety
+  - technical
+  - trustees
+  - trusts
+  - women
+  - youth
   name: Employee Benefits Security Administration
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -401,70 +394,56 @@ departments:
     assistance with finding jobs and careers.
   fax: 202-693-2844
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Aged
-  - Agricultural commodities
-  - Agriculture
-  - Aliens
-  - Australia
-  - Civil rights
-  - Claims
-  - Courts
-  - Disaster assistance
-  - Education
-  - Employment
-  - Employment and Training Administration
-  - Employment taxes
-  - Equal educational opportunity
-  - Equal employment opportunity
-  - Foreign officials
-  - Forests and forest products
-  - Fraud
-  - Government contracts
-  - Government employees
-  - Government procurement
-  - Grant programs
-  - Grant programs-Indians
-  - Grant programs-labor
-  - Guam
-  - Hawaiian Natives
-  - Health professions
-  - Homeless
-  - Housing
-  - Housing standards
-  - Immigration
-  - Indemnity payments
-  - Indians
-  - Individuals with disabilities
-  - Investigations
-  - Labor
-  - Lobbying
-  - Longshore and harbor workers
-  - Manpower training programs
-  - Migrant labor
-  - Minimum wages
-  - Nursery stock
-  - Passports and visas
-  - Penalties
-  - Privacy
-  - Religious discrimination
-  - Relocation assistance
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Seamen
-  - Sex discrimination
-  - Statistics
-  - Students
-  - Trade adjustment assistance
-  - Transportation
-  - Unemployment compensation
-  - Veterans
-  - Virgin Islands
-  - Vocational education
-  - Wages
-  - Workers' compensation
-  - Youth
+  - adjustment
+  - administration
+  - agricultural
+  - aliens
+  - assistance
+  - australia
+  - commodities
+  - compensation
+  - courts
+  - disaster
+  - forest
+  - forests
+  - fraud
+  - guam
+  - harbor
+  - hawaiian
+  - homeless
+  - housing
+  - immigration
+  - indemnity
+  - lobbying
+  - longshore
+  - manpower
+  - migrant
+  - minimum
+  - natives
+  - nursery
+  - officials
+  - passports
+  - payments
+  - procurement
+  - programs-indians
+  - programs-labor
+  - religious
+  - relocation
+  - seamen
+  - sex
+  - standards
+  - statistics
+  - stock
+  - students
+  - training
+  - unemployment
+  - veterans
+  - virgin
+  - visas
+  - wages
+  - workers
+  - workers'
+  - youth
   name: Employment & Training Administration
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -626,54 +605,51 @@ departments:
   - foiarequests@dol.gov
   fax: 202-963-9441
   keywords:
-  - Administrative practice and procedure
-  - Agriculture
-  - Aliens
-  - Asbestos
-  - Black lung benefits
-  - Chemicals
-  - Child labor
-  - Coal
-  - Colleges and universities
-  - Communications equipment
-  - Education
-  - Electric power
-  - Emergency medical services
-  - Employee benefit plans
-  - Employment
-  - Environmental impact statements
-  - Explosives
-  - Fire prevention
-  - Gases
-  - Hazardous substances
-  - Health professions
-  - Housing
-  - Insurance
-  - Intergovernmental relations
-  - Investigations
-  - Labeling
-  - Law enforcement
-  - Metals
-  - Migrant labor
-  - Mine safety and health
-  - Minimum wages
-  - Motor vehicle safety
-  - Noise control
-  - Occupational safety and health
-  - Penalties
-  - Radiation protection
-  - Radio
-  - Reporting and recordkeeping requirements
-  - Research
-  - Safety
-  - Students
-  - Surface mining
-  - Television
-  - Trusts and trustees
-  - Underground mining
-  - Wages
-  - Water supply
-  - Whistleblowing
+  - aliens
+  - asbestos
+  - benefit
+  - benefits
+  - black
+  - chemicals
+  - child
+  - coal
+  - colleges
+  - emergency
+  - employee
+  - equipment
+  - explosives
+  - fire
+  - gases
+  - hazardous
+  - impact
+  - labeling
+  - lung
+  - medical
+  - metals
+  - migrant
+  - mine
+  - minimum
+  - mining
+  - noise
+  - occupational
+  - plans
+  - prevention
+  - radiation
+  - radio
+  - services
+  - statements
+  - students
+  - substances
+  - supply
+  - surface
+  - television
+  - trustees
+  - trusts
+  - underground
+  - universities
+  - vehicle
+  - wages
+  - whistleblowing
   name: Mine Safety & Health Administration
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -983,20 +959,11 @@ departments:
   - foiarequests@dol.gov
   fax: 202-693-5538
   keywords:
-  - Administrative practice and procedure
-  - Civil rights
-  - Construction industry
-  - Employment
-  - Equal employment opportunity
-  - Government contracts
-  - Government procurement
-  - Individuals with disabilities
-  - Investigations
-  - Labor
-  - Religious discrimination
-  - Reporting and recordkeeping requirements
-  - Veterans
-  - Women
+  - construction
+  - procurement
+  - religious
+  - veterans
+  - women
   name: Office of Federal Contract Compliance Programs
   phone: 202-693-5500
   public_liaison:
@@ -1083,14 +1050,10 @@ departments:
     street: 200 Constitution Avenue, NW
     zip: '20210'
   keywords:
-  - Administrative practice and procedure
-  - Government contracts
-  - Insurance companies
-  - Labor management relations
-  - Labor unions
-  - Mass transportation
-  - Reporting and recordkeeping requirements
-  - Surety bonds
+  - companies
+  - mass
+  - surety
+  - unions
   name: Office of Labor-Management Standards
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1179,29 +1142,29 @@ departments:
     street: 200 Constitution Avenue, NW
     zip: '20210'
   keywords:
-  - Administrative practice and procedure
-  - Black lung benefits
-  - Cancer
-  - Chemicals
-  - Claims
-  - Government employees
-  - Health care
-  - Health professions
-  - Insurance companies
-  - Kidney diseases
-  - Labor
-  - Longshore and harbor workers
-  - Lung diseases
-  - Miners
-  - Organization and functions (Government agencies)
-  - Radioactive materials
-  - Reporting and recordkeeping requirements
-  - Underground mining
-  - Uranium
-  - Vocational rehabilitation
-  - Whistleblowing
-  - Workers' compensation
-  - X-rays
+  - benefits
+  - black
+  - cancer
+  - care
+  - chemicals
+  - companies
+  - compensation
+  - diseases
+  - harbor
+  - kidney
+  - longshore
+  - lung
+  - materials
+  - miners
+  - mining
+  - radioactive
+  - rehabilitation
+  - underground
+  - uranium
+  - whistleblowing
+  - workers
+  - workers'
+  - x-rays
   name: Office of Workers' Compensation Programs
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1393,64 +1356,52 @@ departments:
     standards, and by providing training, outreach, education and assistance.
   fax: 202-693-1635
   keywords:
-  - Administrative practice and procedure
-  - Advisory committees
-  - Agriculture
-  - Asbestos
-  - Blood
-  - Blood diseases
-  - Cancer
-  - Chemicals
-  - Confidential business information
-  - Construction industry
-  - Consumer protection
-  - Diving
-  - Electric power
-  - Employment
-  - Environmental protection
-  - Explosives
-  - Fire prevention
-  - Freedom of information
-  - Freight
-  - Gases
-  - Government employees
-  - Grant programs-labor
-  - Hazardous substances
-  - Health
-  - Health care
-  - Health facilities
-  - Health professions
-  - Health records
-  - Health statistics
-  - Highway safety
-  - Hospitals
-  - Intergovernmental relations
-  - Investigations
-  - Labeling
-  - Laboratories
-  - Law enforcement
-  - Longshore and harbor workers
-  - Marine safety
-  - Mass transportation
-  - Motor carriers
-  - Motor vehicle safety
-  - National parks
-  - Occupational Safety and Health Administration
-  - Occupational safety and health
-  - Pipeline safety
-  - Pipelines
-  - Privacy
-  - Radiation protection
-  - Railroads
-  - Reporting and recordkeeping requirements
-  - Safety
-  - Seamen
-  - Signs and symbols
-  - Small businesses
-  - Technical assistance
-  - Transportation
-  - Vessels
-  - Whistleblowing
+  - administration
+  - advisory
+  - asbestos
+  - blood
+  - businesses
+  - cancer
+  - care
+  - chemicals
+  - committees
+  - confidential
+  - construction
+  - consumer
+  - diseases
+  - diving
+  - explosives
+  - fire
+  - freight
+  - gases
+  - harbor
+  - hazardous
+  - highway
+  - hospitals
+  - labeling
+  - laboratories
+  - longshore
+  - marine
+  - mass
+  - motor
+  - occupational
+  - parks
+  - pipeline
+  - pipelines
+  - prevention
+  - programs-labor
+  - radiation
+  - railroads
+  - seamen
+  - signs
+  - small
+  - statistics
+  - substances
+  - symbols
+  - technical
+  - vehicle
+  - whistleblowing
+  - workers
   name: Occupational Safety & Health Administration
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1556,14 +1507,8 @@ departments:
   description: VETS provides resources to prepare and assist veterans obtain meaningful
     careers and maximize their employment opportunities.
   keywords:
-  - Administrative practice and procedure
-  - Employment
-  - Government contracts
-  - Grant programs
-  - Grant programs-labor
-  - Labor
-  - Reporting and recordkeeping requirements
-  - Veterans
+  - programs-labor
+  - veterans
   name: Veterans' Employment & Training Service
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1667,69 +1612,67 @@ departments:
     street: 200 Constitution Avenue, N.W.
     zip: '20210'
   keywords:
-  - Administrative practice and procedure
-  - Agricultural commodities
-  - Agriculture
-  - Aliens
-  - American Samoa
-  - Black lung benefits
-  - Chemicals
-  - Child labor
-  - Coal
-  - Colleges and universities
-  - Communications equipment
-  - Construction industry
-  - Education
-  - Electric power
-  - Emergency medical services
-  - Employee benefit plans
-  - Employment
-  - Environmental impact statements
-  - Explosives
-  - Fire prevention
-  - Firefighters
-  - Forests and forest products
-  - Fraud
-  - Gases
-  - Government contracts
-  - Hazardous substances
-  - Health
-  - Health insurance
-  - Health professions
-  - Housing
-  - Housing standards
-  - Immigration
-  - Insurance
-  - Intergovernmental relations
-  - Investigations
-  - Irrigation
-  - Labor
-  - Labor management relations
-  - Law enforcement
-  - Law enforcement officers
-  - Maternal and child health
-  - Metals
-  - Migrant labor
-  - Mine safety and health
-  - Minimum wages
-  - Motor vehicle safety
-  - Noise control
-  - Nursery stock
-  - Occupational safety and health
-  - Passports and visas
-  - Penalties
-  - Radiation protection
-  - Radio
-  - Reporting and recordkeeping requirements
-  - Research
-  - Students
-  - Teachers
-  - Television
-  - Transportation
-  - Trusts and trustees
-  - Wages
-  - Water supply
-  - Whistleblowing
+  - agricultural
+  - aliens
+  - american
+  - benefit
+  - benefits
+  - black
+  - chemicals
+  - child
+  - coal
+  - colleges
+  - commodities
+  - construction
+  - emergency
+  - employee
+  - equipment
+  - explosives
+  - fire
+  - firefighters
+  - forest
+  - forests
+  - fraud
+  - gases
+  - hazardous
+  - housing
+  - immigration
+  - impact
+  - irrigation
+  - labor
+  - lung
+  - maternal
+  - medical
+  - metals
+  - migrant
+  - mine
+  - minimum
+  - noise
+  - nursery
+  - occupational
+  - officers
+  - passports
+  - plans
+  - prevention
+  - radiation
+  - radio
+  - samoa
+  - services
+  - standards
+  - statements
+  - stock
+  - students
+  - substances
+  - supply
+  - teachers
+  - television
+  - trustees
+  - trusts
+  - universities
+  - vehicle
+  - visas
+  - wages
+  - whistleblowing
   name: Wage and Hour Division
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -1914,234 +1857,225 @@ emails:
 - foiarequests@dol.gov
 fax: 202-693-5389
 keywords:
-- Accountants
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Advertising
-- Advisory committees
-- Aged
-- Agricultural commodities
-- Agriculture
-- Airports
-- Aliens
-- American Samoa
-- Asbestos
-- Australia
-- Black lung benefits
-- Blind
-- Blood
-- Blood diseases
-- Bonds
-- Broadband
-- Brokers
-- Buildings and facilities
-- Business and industry
-- Cancer
-- Carpools
-- Chemicals
-- Child labor
-- Civil rights
-- Claims
-- Classified information
-- Coal
-- Colleges and universities
-- Communications
-- Communications equipment
-- Community development
-- Confidential business information
-- Construction industry
-- Consumer protection
-- Copyright
-- Courts
-- Credit
-- Cultural exchange programs
-- Disaster assistance
-- Diving
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Emergency medical services
-- Employee benefit plans
-- Employment
-- Employment and Training Administration
-- Employment taxes
-- Environmental impact statements
-- Environmental protection
-- Equal access to justice
-- Equal educational opportunity
-- Equal employment opportunity
-- Excise taxes
-- Explosives
-- Federal buildings and facilities
-- Federally affected areas
-- Fire prevention
-- Firefighters
-- Foreign officials
-- Forests and forest products
-- Fraud
-- Freedom of information
-- Freight
-- Gases
-- Government contracts
-- Government employees
-- Government procurement
-- Government property management
-- Grant programs
-- Grant programs-Indians
-- Grant programs-business
-- Grant programs-education
-- Grant programs-health
-- Grant programs-labor
-- Grant programs-social programs
-- Guam
-- Hawaiian Natives
-- Hazardous substances
-- Health
-- Health care
-- Health facilities
-- Health insurance
-- Health professions
-- Health records
-- Health statistics
-- Highway safety
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Housing
-- Housing standards
-- Human research subjects
-- Immigration
-- Income taxes
-- Indemnity payments
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Insurance companies
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Investments
-- Iraq
-- Irrigation
-- Kidney diseases
-- Kuwait
-- Labeling
-- Labor
-- Labor management relations
-- Labor unions
-- Laboratories
-- Law enforcement
-- Law enforcement officers
-- Lawyers
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-business
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-health
-- Loan programs-housing and community development
-- Lobbying
-- Longshore and harbor workers
-- Lung diseases
-- Manpower training programs
-- Marine safety
-- Mass transportation
-- Maternal and child health
-- Medicaid
-- Metals
-- Migrant labor
-- Mine safety and health
-- Miners
-- Mines
-- Minimum wages
-- Mortgage insurance
-- Mortgages
-- Motor carriers
-- Motor vehicle safety
-- National parks
-- Noise control
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nursery stock
-- Occupational Safety and Health Administration
-- Occupational safety and health
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Passports and visas
-- Penalties
-- Pipeline safety
-- Pipelines
-- Privacy
-- Private schools
-- Public assistance programs
-- Radiation protection
-- Radio
-- Radioactive materials
-- Railroads
-- Religious discrimination
-- Relocation assistance
-- Reporting and recordkeeping requirements
-- Research
-- Retirement
-- Rural areas
-- Safety
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seamen
-- Securities
-- Sex discrimination
-- Signs and symbols
-- Small businesses
-- State and local governments
-- Statistics
-- Student aid
-- Students
-- Sunshine Act
-- Surety bonds
-- Surface mining
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Television
-- Trade adjustment assistance
-- Transportation
-- Trusts and trustees
-- Underground mining
-- Unemployment compensation
-- Uranium
-- Urban areas
-- Vessels
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Whistleblowing
-- Women
-- Workers' compensation
-- X-rays
-- Youth
+- access
+- accountants
+- act
+- adjustment
+- administration
+- adult
+- advertising
+- advisory
+- affected
+- agricultural
+- aid
+- airports
+- aliens
+- american
+- asbestos
+- assistance
+- australia
+- benefit
+- benefits
+- black
+- blind
+- blood
+- bonds
+- broadband
+- brokers
+- businesses
+- cancer
+- care
+- carpools
+- chemicals
+- child
+- classified
+- coal
+- colleges
+- committees
+- commodities
+- communications
+- companies
+- compensation
+- confidential
+- construction
+- consumer
+- copyright
+- courts
+- cultural
+- disadvantaged
+- disaster
+- diseases
+- disposal
+- diving
+- elementary
+- emergency
+- employee
+- equipment
+- exchange
+- excise
+- explosives
+- federally
+- fellowships
+- fire
+- firefighters
+- forest
+- forests
+- fraud
+- freight
+- gases
+- governments
+- guam
+- harbor
+- hawaiian
+- hazardous
+- highway
+- highways
+- home
+- homeless
+- hospitals
+- hostages
+- housing
+- human
+- immigration
+- impact
+- improvement
+- indemnity
+- indians-education
+- industry
+- international
+- inventions
+- investments
+- iraq
+- irrigation
+- justice
+- kidney
+- kuwait
+- labeling
+- labor
+- laboratories
+- lawyers
+- lebanon
+- lobbying
+- local
+- longshore
+- lung
+- management
+- manpower
+- mariana
+- marine
+- mass
+- materials
+- maternal
+- medicaid
+- medical
+- metals
+- migrant
+- mine
+- miners
+- mines
+- minimum
+- mining
+- mortgage
+- mortgages
+- motor
+- natives
+- noise
+- nonprofit
+- northern
+- nursery
+- occupational
+- officers
+- officials
+- pacific
+- parks
+- passports
+- patents
+- payments
+- pipeline
+- pipelines
+- plans
+- prevention
+- private
+- procurement
+- programs-agriculture
+- programs-business
+- programs-communications
+- programs-education
+- programs-energy
+- programs-health
+- programs-indians
+- programs-labor
+- programs-social
+- radiation
+- radio
+- radioactive
+- railroads
+- rates
+- rehabilitation
+- religious
+- relocation
+- retirement
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seamen
+- secondary
+- services
+- sex
+- signs
+- small
+- standards
+- state
+- statements
+- statistics
+- stock
+- student
+- students
+- study
+- subjects
+- substances
+- sunshine
+- supply
+- surety
+- surface
+- symbols
+- taxes
+- teachers
+- technical
+- telecommunications
+- telephone
+- television
+- territory
+- training
+- treatment
+- trust
+- trustees
+- trusts
+- underground
+- unemployment
+- unions
+- universities
+- uranium
+- urban
+- utilities
+- vehicle
+- veterans
+- virgin
+- visas
+- vocational
+- wages
+- waste
+- watersheds
+- whistleblowing
+- women
+- workers
+- workers'
+- x-rays
+- youth
 name: Department of Labor
 phone: 202-693-5391
 public_liaison:

--- a/contacts/data/US ADF.yaml
+++ b/contacts/data/US ADF.yaml
@@ -83,17 +83,10 @@ departments:
 description: The African Development Foundation provides grants to community groups
   and small enterprises that benefit under-served and marginalized groups in Africa.
 keywords:
-- Administrative practice and procedure
-- Government employees
-- Grant programs
-- Health facilities
-- Health insurance
-- Health professions
-- Hostages
-- Iraq
-- Kuwait
-- Lebanon
-- Loan programs
+- hostages
+- iraq
+- kuwait
+- lebanon
 name: United States African Development Foundation
 request_time_stats:
   '2010':

--- a/contacts/data/US RRB.yaml
+++ b/contacts/data/US RRB.yaml
@@ -128,52 +128,44 @@ departments:
 description: The Railroad Retirement Board administers retirement and survivor, unemployment
   and sickness benefits for U.S. railroad workers and their families.
 keywords:
-- Administrative practice and procedure
-- Aged
-- Air traffic controllers
-- Alcoholism
-- Alimony
-- Archives and records
-- Blind
-- Cemeteries
-- Child support
-- Claims
-- Courts
-- Crime
-- Disability benefits
-- Drug abuse
-- Firefighters
-- Flags
-- Freedom of information
-- Government contracts
-- Government employees
-- Government property
-- Income taxes
-- Insurance
-- Intergovernmental relations
-- Inventions and patents
-- Investigations
-- Law enforcement officers
-- Medicaid
-- Organization and functions (Government agencies)
-- Parking
-- Penalties
-- Privacy
-- Railroad employees
-- Railroad retirement
-- Railroad unemployment insurance
-- Reporting and recordkeeping requirements
-- Retirement
-- Seals and insignia
-- Security measures
-- Social security
-- Sunshine Act
-- Supplemental Security Income (SSI)
-- Travel and transportation expenses
-- Treaties
-- Veterans
-- Vocational rehabilitation
-- Wages
+- act
+- alcoholism
+- alimony
+- archives
+- benefits
+- blind
+- cemeteries
+- child
+- controllers
+- courts
+- crime
+- disability
+- expenses
+- firefighters
+- flags
+- income
+- insignia
+- inventions
+- measures
+- medicaid
+- officers
+- parking
+- patents
+- railroad
+- rehabilitation
+- retirement
+- seals
+- security
+- social
+- ssi
+- sunshine
+- supplemental
+- support
+- traffic
+- travel
+- treaties
+- unemployment
+- veterans
 name: Railroad Retirement Board
 request_form: https://secure.rrb.gov/efoia/
 usa_id: '52657'

--- a/contacts/data/USAID.yaml
+++ b/contacts/data/USAID.yaml
@@ -95,127 +95,102 @@ description: 'The U.S. Agency for International Development (USAID) is the princ
   U.S. agency to extend assistance to countries recovering from disaster, trying to
   escape poverty, and engaging in democratic reforms. '
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agricultural commodities
-- Agriculture
-- Airports
-- American Samoa
-- Antitrust
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Civil rights
-- Claims
-- Colleges and universities
-- Communications
-- Community development
-- Copyright
-- Credit
-- Cultural exchange programs
-- Disaster assistance
-- Drug abuse
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Environmental impact statements
-- Environmental protection
-- Equal educational opportunity
-- Equal employment opportunity
-- Federal buildings and facilities
-- Federally affected areas
-- Food assistance programs
-- Foreign aid
-- Foreign relations
-- Fraud
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-foreign relations
-- Grant programs-health
-- Grant programs-social programs
-- Guam
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Human research subjects
-- Indians
-- Indians-education
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Lebanon
-- Loan programs
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-foreign relations
-- Loan programs-housing and community development
-- Manpower training programs
-- Maritime carriers
-- Mass transportation
-- Migrant labor
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Pacific Islands Trust Territory
-- Penalties
-- Privacy
-- Private schools
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Research
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Securities
-- Sex discrimination
-- Small businesses
-- State and local governments
-- Student aid
-- Teachers
-- Telecommunications
-- Telephone
-- Urban areas
-- Veterans
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- adult
+- affected
+- agricultural
+- aid
+- airports
+- american
+- antitrust
+- blind
+- broadband
+- businesses
+- colleges
+- commodities
+- construction
+- copyright
+- cultural
+- disadvantaged
+- disaster
+- disposal
+- elementary
+- exchange
+- federally
+- fellowships
+- food
+- fraud
+- governments
+- guam
+- highways
+- home
+- homeless
+- hospitals
+- hostages
+- human
+- impact
+- improvement
+- indians-education
+- international
+- inventions
+- iraq
+- kuwait
+- lebanon
+- local
+- manpower
+- mariana
+- maritime
+- mass
+- migrant
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- pacific
+- patents
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-foreign
+- programs-social
+- railroads
+- rates
+- rehabilitation
+- religious
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- secondary
+- sex
+- small
+- state
+- statements
+- student
+- study
+- subjects
+- supply
+- teachers
+- telecommunications
+- telephone
+- territory
+- training
+- treatment
+- trust
+- universities
+- urban
+- utilities
+- veterans
+- virgin
+- vocational
+- waste
+- watersheds
+- women
 name: U.S. Agency for International Development
 request_time_stats:
   '2010':

--- a/contacts/data/USCCR.yaml
+++ b/contacts/data/USCCR.yaml
@@ -67,19 +67,10 @@ departments:
 description: The U.S. Commission on Civil Rights is an independent, bipartisan agency
   charged with monitoring federal civil rights enforcement.
 keywords:
-- Administrative practice and procedure
-- Advisory committees
-- Civil rights
-- Claims
-- Conflict of interests
-- Equal employment opportunity
-- Federal buildings and facilities
-- Freedom of information
-- Government employees
-- Individuals with disabilities
-- Organization and functions (Government agencies)
-- Privacy
-- Sunshine Act
+- act
+- advisory
+- committees
+- sunshine
 name: Commission on Civil Rights
 request_time_stats:
   '2010':

--- a/contacts/data/USDA.yaml
+++ b/contacts/data/USDA.yaml
@@ -28,95 +28,99 @@ departments:
     phone:
     - 202-720-3785
   keywords:
-  - Administrative practice and procedure
-  - Advertising
-  - Advisory committees
-  - Agricultural commodities
-  - Agricultural research
-  - Agriculture
-  - Almonds
-  - Animals
-  - Apples
-  - Apricots
-  - Archives and records
-  - Avocados
-  - Blueberries
-  - Brokers
-  - Cattle
-  - Cheese
-  - Cherries
-  - Citrus fruits
-  - Claims
-  - Commodity futures
-  - Cotton
-  - Cranberries
-  - Dairy products
-  - Dates
-  - Eggs and egg products
-  - Exports
-  - Filberts
-  - Fish
-  - Food grades and standards
-  - Food labeling
-  - Food packaging
-  - Freedom of information
-  - Frozen foods
-  - Fruit juices
-  - Fruits
-  - Government publications
-  - Grapefruit
-  - Grapes
-  - Hazelnuts
-  - Hogs
-  - Honey
-  - Imports
-  - Investigations
-  - Kiwifruit
-  - Labeling
-  - Laboratories
-  - Limes
-  - Livestock
-  - Marketing agreements
-  - Meat and meat products
-  - Melons
-  - Milk
-  - Milk marketing orders
-  - Mushrooms
-  - Nectarines
-  - Nuts
-  - Oils and fats
-  - Olives
-  - Onions
-  - Oranges
-  - Peaches
-  - Peanuts
-  - Pears
-  - Penalties
-  - Pistachios
-  - Plants
-  - Plums
-  - Popcorn
-  - Potatoes
-  - Poultry and poultry products
-  - Prunes
-  - Raisins
-  - Reporting and recordkeeping requirements
-  - Research
-  - Seals and insignia
-  - Seeds
-  - Sheep
-  - Soil conservation
-  - Soybeans
-  - Spearmint oil
-  - Tangelos
-  - Tangerines
-  - Tobacco
-  - Tomatoes
-  - Trees
-  - Vegetables
-  - Walnuts
-  - Warehouses
-  - Watermelons
+  - advertising
+  - advisory
+  - agreements
+  - agricultural
+  - almonds
+  - animals
+  - apples
+  - apricots
+  - archives
+  - avocados
+  - blueberries
+  - brokers
+  - cattle
+  - cheese
+  - cherries
+  - citrus
+  - committees
+  - commodities
+  - commodity
+  - conservation
+  - cotton
+  - cranberries
+  - dairy
+  - dates
+  - egg
+  - eggs
+  - exports
+  - fats
+  - filberts
+  - fish
+  - food
+  - foods
+  - frozen
+  - fruit
+  - fruits
+  - futures
+  - grades
+  - grapefruit
+  - grapes
+  - hazelnuts
+  - hogs
+  - honey
+  - imports
+  - insignia
+  - juices
+  - kiwifruit
+  - labeling
+  - laboratories
+  - limes
+  - livestock
+  - marketing
+  - meat
+  - melons
+  - milk
+  - mushrooms
+  - nectarines
+  - nuts
+  - oil
+  - oils
+  - olives
+  - onions
+  - oranges
+  - orders
+  - packaging
+  - peaches
+  - peanuts
+  - pears
+  - pistachios
+  - plants
+  - plums
+  - popcorn
+  - potatoes
+  - poultry
+  - products
+  - prunes
+  - publications
+  - raisins
+  - seals
+  - seeds
+  - sheep
+  - soil
+  - soybeans
+  - spearmint
+  - standards
+  - tangelos
+  - tangerines
+  - tobacco
+  - tomatoes
+  - trees
+  - vegetables
+  - walnuts
+  - warehouses
+  - watermelons
   name: Agricultural Marketing Service
   phone: 202-720-3785
   public_liaison:
@@ -192,69 +196,78 @@ departments:
   - foia.officer@aphis.usda.gov
   fax: 301-734-5941
   keywords:
-  - Administrative practice and procedure
-  - Agricultural commodities
-  - Agricultural research
-  - Animal biologics
-  - Animal diseases
-  - Animal feeds
-  - Animal welfare
-  - Animals
-  - Authority delegations (Government agencies)
-  - Bees
-  - Bison
-  - Cattle
-  - Cervids
-  - Civil rights
-  - Coffee
-  - Cotton
-  - Cottonseeds
-  - Customs duties and inspection
-  - District of Columbia
-  - Endangered and threatened species
-  - Equal access to justice
-  - Exports
-  - Fruits
-  - Goats
-  - Government employees
-  - Guam
-  - Hay
-  - Hogs
-  - Honey
-  - Horses
-  - Imports
-  - Indemnity payments
-  - Labeling
-  - Laboratories
-  - Law enforcement
-  - Livestock
-  - Marine mammals
-  - Meat and meat products
-  - Meat inspection
-  - Medical research
-  - Milk
-  - Nursery stock
-  - Organization and functions (Government agencies)
-  - Packaging and containers
-  - Pets
-  - Plant diseases and pests
-  - Postal Service
-  - Poultry and poultry products
-  - Puerto Rico
-  - Quarantine
-  - Reporting and recordkeeping requirements
-  - Research
-  - Rice
-  - Seeds
-  - Seizures and forfeitures
-  - Sheep
-  - Straw
-  - Transportation
-  - Travel and transportation expenses
-  - Tuberculosis
-  - Vegetables
-  - Veterinarians
-  - Virgin Islands
+  - access
+  - agricultural
+  - animal
+  - animals
+  - authority
+  - bees
+  - biologics
+  - bison
+  - cattle
+  - cervids
+  - coffee
+  - columbia
+  - commodities
+  - containers
+  - cotton
+  - cottonseeds
+  - customs
+  - delegations
+  - diseases
+  - district
+  - duties
+  - endangered
+  - expenses
+  - exports
+  - feeds
+  - forfeitures
+  - fruits
+  - goats
+  - guam
+  - hay
+  - hogs
+  - honey
+  - horses
+  - imports
+  - indemnity
+  - inspection
+  - justice
+  - labeling
+  - laboratories
+  - livestock
+  - mammals
+  - marine
+  - meat
+  - medical
+  - milk
+  - nursery
+  - packaging
+  - payments
+  - pests
+  - pets
+  - plant
+  - postal
+  - poultry
+  - products
+  - puerto
+  - quarantine
+  - rice
+  - rico
+  - seeds
+  - seizures
+  - service
+  - sheep
+  - species
+  - stock
+  - straw
+  - threatened
+  - travel
+  - tuberculosis
+  - vegetables
+  - veterinarians
+  - virgin
+  - welfare
   misc:
     FOIA Director:
       name: Tonya Woods
@@ -410,190 +423,188 @@ departments:
     phone:
     - 202-720-1598
   keywords:
-  - Accounting
-  - Acreage allotments
-  - Administrative practice and procedure
-  - Adult education
-  - Aged
-  - Agricultural commodities
-  - Agriculture
-  - American Samoa
-  - Animal feeds
-  - Apples
-  - Bankruptcy
-  - Barley
-  - Beans
-  - Blind
-  - Broadband
-  - Business and industry
-  - Citrus fruits
-  - Civil rights
-  - Claims
-  - Coal
-  - Colleges and universities
-  - Communications
-  - Communications equipment
-  - Community development
-  - Confidential business information
-  - Conflict of interests
-  - Cooperatives
-  - Copyright
-  - Cotton
-  - Cottonseeds
-  - Cranberries
-  - Credit
-  - Crop insurance
-  - Cultural exchange programs
-  - Dairy products
-  - Disaster assistance
-  - Drug traffic control
-  - Education
-  - Education of disadvantaged
-  - Education of individuals with disabilities
-  - Educational facilities
-  - Educational research
-  - Educational study programs
-  - Electric power
-  - Electric power rates
-  - Electric utilities
-  - Elementary and secondary education
-  - Employment
-  - Energy
-  - Energy conservation
-  - Environmental impact statements
-  - Environmental protection
-  - Equal educational opportunity
-  - Fair housing
-  - Federally affected areas
-  - Feed grains
-  - Fish
-  - Flood insurance
-  - Flood plains
-  - Forests and forest products
-  - Fraud
-  - Fruits
-  - Government contracts
-  - Government employees
-  - Government procurement
-  - Government property
-  - Government property management
-  - Government securities
-  - Grains
-  - Grant programs
-  - Grant programs-Indians
-  - Grant programs-agriculture
-  - Grant programs-business
-  - Grant programs-communications
-  - Grant programs-education
-  - Grant programs-energy
-  - Grant programs-health
-  - Grant programs-housing and community development
-  - Grant programs-natural resources
-  - Grant programs-social programs
-  - Grazing lands
-  - Guam
-  - Historic preservation
-  - Home improvement
-  - Homeless
-  - Honey
-  - Hospitals
-  - Housing
-  - Housing standards
-  - Human research subjects
-  - Imports
-  - Indemnity payments
-  - Indians
-  - Indians-education
-  - Insurance
-  - Intergovernmental relations
-  - International organizations
-  - Inventions and patents
-  - Investments
-  - Legal services
-  - Livestock
-  - Loan programs
-  - Loan programs-Indians
-  - Loan programs-agriculture
-  - Loan programs-business
-  - Loan programs-communications
-  - Loan programs-energy
-  - Loan programs-housing and community development
-  - Loan programs-natural resources
-  - Lobbying
-  - Low and moderate income housing
-  - Manpower training programs
-  - Manufactured homes
-  - Marital status discrimination
-  - Marketing quotas
-  - Migrant labor
-  - Military personnel
-  - Milk
-  - Mortgage insurance
-  - Mortgages
-  - National defense
-  - Natural resources
-  - Nonprofit organizations
-  - Northern Mariana Islands
-  - Nuclear energy
-  - Nursery stock
-  - Nuts
-  - Oats
-  - Oilseeds
-  - Pacific Islands Trust Territory
-  - Packaging and containers
-  - Peanuts
-  - Penalties
-  - Plants
-  - Price support programs
-  - Privacy
-  - Private schools
-  - Public housing
-  - Rent subsidies
-  - Reporting and recordkeeping requirements
-  - Rice
-  - Rural areas
-  - Scholarships and fellowships
-  - School construction
-  - Schools
-  - Science and technology
-  - Securities
-  - Seeds
-  - Sex discrimination
-  - Sheep
-  - Small businesses
-  - Soil conservation
-  - Soybeans
-  - State and local governments
-  - Student aid
-  - Sugar
-  - Surety bonds
-  - Surplus Government property
-  - Taxes
-  - Teachers
-  - Telecommunications
-  - Telephone
-  - Television
-  - Tobacco
-  - Transportation
-  - Trees
-  - Truth in lending
-  - Urban areas
-  - Veterans
-  - Virgin Islands
-  - Vocational education
-  - Vocational rehabilitation
-  - Volunteers
-  - Warehouses
-  - Waste treatment and disposal
-  - Water pollution control
-  - Water resources
-  - Water supply
-  - Watersheds
-  - Wheat
-  - Wildlife
-  - Women
-  - Wool
-  - Youth
+  - acreage
+  - adult
+  - affected
+  - agricultural
+  - aid
+  - allotments
+  - american
+  - animal
+  - apples
+  - bankruptcy
+  - barley
+  - beans
+  - blind
+  - broadband
+  - businesses
+  - citrus
+  - coal
+  - colleges
+  - commodities
+  - communications
+  - confidential
+  - conservation
+  - construction
+  - containers
+  - cooperatives
+  - copyright
+  - cotton
+  - cottonseeds
+  - cranberries
+  - crop
+  - cultural
+  - dairy
+  - defense
+  - disadvantaged
+  - disaster
+  - disposal
+  - elementary
+  - energy
+  - equipment
+  - exchange
+  - fair
+  - federally
+  - feed
+  - feeds
+  - fellowships
+  - fish
+  - flood
+  - forest
+  - forests
+  - fraud
+  - fruits
+  - governments
+  - grains
+  - grazing
+  - guam
+  - historic
+  - home
+  - homeless
+  - homes
+  - honey
+  - hospitals
+  - housing
+  - human
+  - impact
+  - imports
+  - improvement
+  - indemnity
+  - indians-education
+  - international
+  - inventions
+  - investments
+  - lands
+  - legal
+  - lending
+  - livestock
+  - lobbying
+  - local
+  - low
+  - manpower
+  - manufactured
+  - mariana
+  - marital
+  - marketing
+  - migrant
+  - military
+  - milk
+  - moderate
+  - mortgage
+  - mortgages
+  - natural
+  - nonprofit
+  - northern
+  - nuclear
+  - nursery
+  - nuts
+  - oats
+  - oilseeds
+  - pacific
+  - packaging
+  - patents
+  - payments
+  - peanuts
+  - personnel
+  - plains
+  - plants
+  - preservation
+  - price
+  - private
+  - procurement
+  - products
+  - programs-agriculture
+  - programs-business
+  - programs-communications
+  - programs-education
+  - programs-energy
+  - programs-housing
+  - programs-indians
+  - programs-natural
+  - programs-social
+  - property
+  - quotas
+  - rates
+  - rehabilitation
+  - rent
+  - resources
+  - rice
+  - rural
+  - samoa
+  - scholarships
+  - school
+  - schools
+  - science
+  - secondary
+  - securities
+  - seeds
+  - services
+  - sex
+  - sheep
+  - small
+  - soil
+  - soybeans
+  - standards
+  - state
+  - statements
+  - status
+  - stock
+  - student
+  - study
+  - subjects
+  - subsidies
+  - sugar
+  - supply
+  - support
+  - surety
+  - surplus
+  - teachers
+  - telecommunications
+  - telephone
+  - television
+  - territory
+  - tobacco
+  - traffic
+  - training
+  - treatment
+  - trees
+  - trust
+  - truth
+  - universities
+  - urban
+  - utilities
+  - veterans
+  - virgin
+  - vocational
+  - volunteers
+  - warehouses
+  - waste
+  - watersheds
+  - wheat
+  - wildlife
+  - women
+  - wool
+  - youth
   name: Farm Service Agency
   notes: This office has additional FOIA contact information that can be found by
     visiting its website.
@@ -759,34 +770,37 @@ departments:
   - fsis.foia@usda.gov
   fax: 202-690-3023
   keywords:
-  - Administrative practice and procedure
-  - Animal diseases
-  - Animal welfare
-  - Confidential business information
-  - Crime
-  - Eggs and egg products
-  - Exports
-  - Food additives
-  - Food grades and standards
-  - Food labeling
-  - Food packaging
-  - Freedom of information
-  - Frozen foods
-  - Government employees
-  - Grant programs-agriculture
-  - Imports
-  - Intergovernmental relations
-  - Laboratories
-  - Livestock
-  - Meat and meat products
-  - Meat inspection
-  - Nutrition
-  - Oils and fats
-  - Poultry and poultry products
-  - Reporting and recordkeeping requirements
-  - Seizures and forfeitures
-  - Signs and symbols
-  - Transportation
+  - additives
+  - animal
+  - confidential
+  - crime
+  - diseases
+  - egg
+  - eggs
+  - exports
+  - fats
+  - food
+  - foods
+  - forfeitures
+  - frozen
+  - grades
+  - imports
+  - inspection
+  - labeling
+  - laboratories
+  - livestock
+  - meat
+  - nutrition
+  - oils
+  - packaging
+  - poultry
+  - products
+  - programs-agriculture
+  - seizures
+  - signs
+  - standards
+  - symbols
+  - welfare
   misc:
     FOIA Contact:
       name: Shelia Wright
@@ -874,15 +888,15 @@ departments:
     phone:
     - 202-720-0154
   keywords:
-  - Agricultural commodities
-  - Cheese
-  - Exports
-  - Food assistance programs
-  - Foreign aid
-  - Government procurement
-  - Imports
-  - Reporting and recordkeeping requirements
-  - Trade adjustment assistance
+  - adjustment
+  - agricultural
+  - aid
+  - cheese
+  - commodities
+  - exports
+  - food
+  - imports
+  - procurement
   name: Foreign Agricultural Service
   phone: 202-720-0154
   public_liaison:
@@ -967,58 +981,50 @@ departments:
   - wo_foia@fs.fed.us
   fax: 202-260-3245
   keywords:
-  - Administrative practice and procedure
-  - Agriculture
-  - Alaska
-  - Crime
-  - Crop insurance
-  - Education
-  - Electric power
-  - Environmental impact statements
-  - Environmental protection
-  - Exports
-  - Fire prevention
-  - Fish
-  - Forests and forest products
-  - Freedom of information
-  - Government contracts
-  - Government procurement
-  - Grant programs
-  - Grant programs-natural resources
-  - Highways and roads
-  - Indians
-  - Indians-lands
-  - Intergovernmental relations
-  - Investigations
-  - Law enforcement
-  - Mineral resources
-  - Mineral royalties
-  - Miners
-  - Mines
-  - Museums
-  - National forests
-  - Natural resources
-  - Navigation (air)
-  - Nonprofit organizations
-  - Oil and gas exploration
-  - Organization and functions (Government agencies)
-  - Penalties
-  - Public lands
-  - Range management
-  - Reclamation
-  - Reporting and recordkeeping requirements
-  - Research
-  - Rights-of-way
-  - Science and technology
-  - Seizures and forfeitures
-  - State and local governments
-  - Surety bonds
-  - Traffic regulations
-  - Transportation
-  - Water resources
-  - Wilderness areas
-  - Wildlife
-  - Wildlife refuges
+  - alaska
+  - crime
+  - crop
+  - exploration
+  - exports
+  - fire
+  - fish
+  - forest
+  - forests
+  - forfeitures
+  - gas
+  - governments
+  - highways
+  - impact
+  - indians-lands
+  - lands
+  - local
+  - mineral
+  - miners
+  - mines
+  - museums
+  - natural
+  - navigation
+  - nonprofit
+  - oil
+  - prevention
+  - procurement
+  - programs-natural
+  - range
+  - reclamation
+  - refuges
+  - regulations
+  - resources
+  - rights-of-way
+  - roads
+  - royalties
+  - science
+  - seizures
+  - state
+  - statements
+  - surety
+  - traffic
+  - wilderness
+  - wildlife
   misc:
     'FOIA/PA Officer - ATTN: FOIA/PA Team':
       name: Sherry Turner
@@ -1107,26 +1113,23 @@ departments:
   - joanne.c.peterson@usda.gov
   fax: 202-690-2755
   keywords:
-  - Administrative practice and procedure
-  - Agricultural commodities
-  - Archives and records
-  - Confidential business information
-  - Conflict of interests
-  - Exports
-  - Freedom of information
-  - Grains
-  - Hogs
-  - Intergovernmental relations
-  - Livestock
-  - Measurement standards
-  - Penalties
-  - Poultry and poultry products
-  - Reporting and recordkeeping requirements
-  - Rice
-  - Scientific equipment
-  - Stockyards
-  - Surety bonds
-  - Trade practices
+  - agricultural
+  - archives
+  - commodities
+  - confidential
+  - equipment
+  - exports
+  - grains
+  - hogs
+  - livestock
+  - measurement
+  - poultry
+  - practices
+  - rice
+  - scientific
+  - standards
+  - stockyards
+  - surety
   misc:
     FOIA/PA Officer:
       name: Joanne Peterson
@@ -1302,28 +1305,30 @@ departments:
     phone:
     - 202-690-4985
   keywords:
-  - Administrative practice and procedure
-  - Agriculture
-  - Animals
-  - Disaster assistance
-  - Endangered and threatened species
-  - Environmental impact statements
-  - Environmental protection
-  - Fishing
-  - Flood plains
-  - Forests and forest products
-  - Grant programs
-  - Hunting
-  - Indians
-  - Natural Resources Conservation Service
-  - Natural resources
-  - Reporting and recordkeeping requirements
-  - Rural areas
-  - Soil conservation
-  - State and local governments
-  - Technical assistance
-  - Water resources
-  - Wildlife
+  - animals
+  - conservation
+  - disaster
+  - endangered
+  - fishing
+  - flood
+  - forest
+  - forests
+  - governments
+  - hunting
+  - impact
+  - local
+  - natural
+  - plains
+  - resources
+  - rural
+  - service
+  - soil
+  - species
+  - state
+  - statements
+  - technical
+  - threatened
+  - wildlife
   name: Natural Resources Conservation Service
   phone: 202-690-4985
   public_liaison:
@@ -1462,88 +1467,78 @@ departments:
     phone:
     - 202-720-0995
   keywords:
-  - Accounting
-  - Administrative practice and procedure
-  - Adult education
-  - Aged
-  - Agriculture
-  - American Samoa
-  - Blind
-  - Broadband
-  - Business and industry
-  - Civil rights
-  - Colleges and universities
-  - Communications
-  - Community development
-  - Copyright
-  - Credit
-  - Cultural exchange programs
-  - Education
-  - Education of disadvantaged
-  - Education of individuals with disabilities
-  - Educational facilities
-  - Educational research
-  - Educational study programs
-  - Electric power
-  - Electric power rates
-  - Electric utilities
-  - Elementary and secondary education
-  - Employment
-  - Equal educational opportunity
-  - Federally affected areas
-  - Government contracts
-  - Grant programs
-  - Grant programs-education
-  - Grant programs-health
-  - Grant programs-social programs
-  - Guam
-  - Home improvement
-  - Homeless
-  - Hospitals
-  - Human research subjects
-  - Indians
-  - Indians-education
-  - Insurance
-  - Intergovernmental relations
-  - International organizations
-  - Inventions and patents
-  - Loan programs
-  - Loan programs-agriculture
-  - Loan programs-communications
-  - Loan programs-energy
-  - Loan programs-housing and community development
-  - Manpower training programs
-  - Migrant labor
-  - Mortgage insurance
-  - Mortgages
-  - Nonprofit organizations
-  - Northern Mariana Islands
-  - Pacific Islands Trust Territory
-  - Privacy
-  - Private schools
-  - Reporting and recordkeeping requirements
-  - Rural areas
-  - Scholarships and fellowships
-  - School construction
-  - Schools
-  - Science and technology
-  - Securities
-  - State and local governments
-  - Student aid
-  - Teachers
-  - Telecommunications
-  - Telephone
-  - Urban areas
-  - Veterans
-  - Virgin Islands
-  - Vocational education
-  - Vocational rehabilitation
-  - Waste treatment and disposal
-  - Water pollution control
-  - Water resources
-  - Water supply
-  - Watersheds
-  - Women
+  - adult
+  - affected
+  - aid
+  - american
+  - blind
+  - broadband
+  - colleges
+  - construction
+  - copyright
+  - cultural
+  - disadvantaged
+  - disposal
+  - elementary
+  - exchange
+  - federally
+  - fellowships
+  - governments
+  - guam
+  - home
+  - homeless
+  - hospitals
+  - human
+  - improvement
+  - indians-education
+  - international
+  - inventions
+  - local
+  - manpower
+  - mariana
+  - migrant
+  - mortgage
+  - mortgages
+  - nonprofit
+  - northern
+  - pacific
+  - patents
+  - private
+  - programs-agriculture
+  - programs-communications
+  - programs-education
+  - programs-energy
+  - programs-social
+  - rates
+  - rehabilitation
+  - rural
+  - samoa
+  - scholarships
+  - school
+  - schools
+  - science
+  - secondary
+  - state
+  - student
+  - study
+  - subjects
+  - supply
+  - teachers
+  - telecommunications
+  - telephone
+  - territory
+  - training
+  - treatment
+  - trust
+  - universities
+  - urban
+  - utilities
+  - veterans
+  - virgin
+  - vocational
+  - waste
+  - watersheds
+  - women
   name: Office of the Chief Financial Officer
   phone: 202-720-0995
   public_liaison:
@@ -2071,364 +2066,381 @@ description: The Department of Agriculture provides leadership on food, agricult
 emails:
 - usdafoia@ocio.usda.gov
 keywords:
-- Accounting
-- Acreage allotments
-- Administrative practice and procedure
-- Adult education
-- Advertising
-- Advisory committees
-- Aged
-- Agricultural commodities
-- Agricultural research
-- Agriculture
-- Airports
-- Alaska
-- Aliens
-- Almonds
-- American Samoa
-- Animal biologics
-- Animal diseases
-- Animal feeds
-- Animal welfare
-- Animals
-- Antitrust
-- Apples
-- Apricots
-- Archives and records
-- Authority delegations (Government agencies)
-- Avocados
-- Bankruptcy
-- Barley
-- Beans
-- Bees
-- Bison
-- Blind
-- Blueberries
-- Broadband
-- Brokers
-- Buildings and facilities
-- Business and industry
-- Cattle
-- Cervids
-- Cheese
-- Cherries
-- Citrus fruits
-- Civil rights
-- Claims
-- Classified information
-- Coal
-- Coffee
-- Colleges and universities
-- Commodity futures
-- Communications
-- Communications equipment
-- Community development
-- Computer technology
-- Concessions
-- Confidential business information
-- Conflict of interests
-- Cooperatives
-- Copyright
-- Cotton
-- Cottonseeds
-- Courts
-- Cranberries
-- Credit
-- Crime
-- Crop insurance
-- Cultural exchange programs
-- Customs duties and inspection
-- Dairy products
-- Dates
-- Day care
-- Disaster assistance
-- District of Columbia
-- Drug abuse
-- Drug traffic control
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Eggs and egg products
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Endangered and threatened species
-- Energy
-- Energy conservation
-- Environmental impact statements
-- Environmental protection
-- Equal access to justice
-- Equal educational opportunity
-- Equal employment opportunity
-- Ethics
-- Exports
-- Fair housing
-- Federal Crop Insurance Corporation
-- Federal buildings and facilities
-- Federally affected areas
-- Feed grains
-- Filberts
-- Fire prevention
-- Fish
-- Fisheries
-- Fishing
-- Flood insurance
-- Flood plains
-- Food additives
-- Food and Nutrition Service
-- Food assistance programs
-- Food grades and standards
-- Food labeling
-- Food packaging
-- Food stamps
-- Foreign aid
-- Forests and forest products
-- Fraud
-- Freedom of information
-- Frozen foods
-- Fruit juices
-- Fruits
-- Fuel additives
-- Gasohol
-- Goats
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Government publications
-- Government securities
-- Grains
-- Grant programs
-- Grant programs-Indians
-- Grant programs-agriculture
-- Grant programs-business
-- Grant programs-communications
-- Grant programs-education
-- Grant programs-energy
-- Grant programs-health
-- Grant programs-housing and community development
-- Grant programs-natural resources
-- Grant programs-social programs
-- Grapefruit
-- Grapes
-- Grazing lands
-- Guam
-- Hay
-- Hazelnuts
-- Health facilities
-- Health insurance
-- Health professions
-- Highways and roads
-- Historic preservation
-- Hogs
-- Home improvement
-- Homeless
-- Honey
-- Horses
-- Hospitals
-- Hostages
-- Housing
-- Housing standards
-- Human research subjects
-- Hunting
-- Imports
-- Income taxes
-- Indemnity payments
-- Indians
-- Indians-education
-- Indians-lands
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Investments
-- Iraq
-- Kiwifruit
-- Kuwait
-- Labeling
-- Laboratories
-- Law enforcement
-- Lawyers
-- Lebanon
-- Legal services
-- Libraries
-- Limes
-- Livestock
-- Loan programs
-- Loan programs-Indians
-- Loan programs-agriculture
-- Loan programs-business
-- Loan programs-communications
-- Loan programs-energy
-- Loan programs-housing and community development
-- Loan programs-natural resources
-- Lobbying
-- Low and moderate income housing
-- Manpower training programs
-- Manufactured homes
-- Marine mammals
-- Marital status discrimination
-- Maritime carriers
-- Marketing agreements
-- Marketing quotas
-- Mass transportation
-- Maternal and child health
-- Measurement standards
-- Meat and meat products
-- Meat inspection
-- Medical research
-- Melons
-- Migrant labor
-- Military personnel
-- Milk
-- Milk marketing orders
-- Mineral resources
-- Mineral royalties
-- Miners
-- Mines
-- Mortgage insurance
-- Mortgages
-- Motion pictures
-- Museums
-- Mushrooms
-- National Arboretum
-- National defense
-- National forests
-- National parks
-- Natural Resources Conservation Service
-- Natural resources
-- Navigation (air)
-- Nectarines
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nuclear energy
-- Nursery stock
-- Nutrition
-- Nuts
-- Oats
-- Oil and gas exploration
-- Oils and fats
-- Oilseeds
-- Olives
-- Onions
-- Oranges
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Packaging and containers
-- Peaches
-- Peanuts
-- Pears
-- Penalties
-- Pets
-- Pistachios
-- Plant diseases and pests
-- Plants
-- Plums
-- Popcorn
-- Postal Service
-- Potatoes
-- Poultry and poultry products
-- Price support programs
-- Privacy
-- Private schools
-- Prunes
-- Public assistance programs
-- Public housing
-- Public lands
-- Puerto Rico
-- Quarantine
-- Railroads
-- Raisins
-- Range management
-- Real property acquisition
-- Reclamation
-- Religious discrimination
-- Rent subsidies
-- Reporting and recordkeeping requirements
-- Research
-- Rice
-- Rights-of-way
-- Rural areas
-- Scholarships and fellowships
-- School breakfast and lunch programs
-- School construction
-- Schools
-- Science and technology
-- Scientific equipment
-- Seals and insignia
-- Securities
-- Seeds
-- Seismic safety
-- Seizures and forfeitures
-- Sex discrimination
-- Sheep
-- Signs and symbols
-- Small businesses
-- Social security
-- Soil conservation
-- Soybeans
-- Spearmint oil
-- State and local governments
-- Stockyards
-- Straw
-- Student aid
-- Students
-- Sugar
-- Surety bonds
-- Surplus Government property
-- Tangelos
-- Tangerines
-- Taxes
-- Teachers
-- Technical assistance
-- Telecommunications
-- Telephone
-- Television
-- Tobacco
-- Tomatoes
-- Trade adjustment assistance
-- Trade practices
-- Traffic regulations
-- Transportation
-- Travel and transportation expenses
-- Trees
-- Truth in lending
-- Tuberculosis
-- Unemployment compensation
-- Uniform System of Accounts
-- Urban areas
-- Vegetables
-- Veterans
-- Veterinarians
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Volunteers
-- Wages
-- Walnuts
-- Warehouses
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watermelons
-- Watersheds
-- Waterways
-- Wheat
-- Wilderness areas
-- Wildlife
-- Wildlife refuges
-- Women
-- Wool
-- Youth
+- access
+- accounts
+- acquisition
+- acreage
+- additives
+- adjustment
+- adult
+- advertising
+- advisory
+- affected
+- agreements
+- agricultural
+- aid
+- airports
+- alaska
+- aliens
+- allotments
+- almonds
+- american
+- animal
+- animals
+- antitrust
+- apples
+- apricots
+- arboretum
+- archives
+- assistance
+- authority
+- avocados
+- bankruptcy
+- barley
+- beans
+- bees
+- biologics
+- bison
+- blind
+- blueberries
+- breakfast
+- broadband
+- brokers
+- businesses
+- care
+- cattle
+- cervids
+- cheese
+- cherries
+- child
+- citrus
+- classified
+- coal
+- coffee
+- colleges
+- columbia
+- committees
+- commodities
+- commodity
+- communications
+- compensation
+- computer
+- concessions
+- confidential
+- conservation
+- construction
+- containers
+- cooperatives
+- copyright
+- corporation
+- cotton
+- cottonseeds
+- courts
+- cranberries
+- crime
+- crop
+- cultural
+- customs
+- dairy
+- dates
+- day
+- defense
+- delegations
+- disadvantaged
+- disaster
+- discrimination
+- diseases
+- disposal
+- district
+- drug
+- duties
+- egg
+- eggs
+- elementary
+- endangered
+- energy
+- equipment
+- ethics
+- exchange
+- expenses
+- exploration
+- exports
+- fair
+- fats
+- federal
+- federally
+- feed
+- feeds
+- fellowships
+- filberts
+- fire
+- fish
+- fisheries
+- fishing
+- flood
+- food
+- foods
+- forest
+- forests
+- forfeitures
+- fraud
+- frozen
+- fruit
+- fruits
+- fuel
+- futures
+- gas
+- gasohol
+- goats
+- governments
+- grades
+- grains
+- grapefruit
+- grapes
+- grazing
+- guam
+- hay
+- hazelnuts
+- highways
+- historic
+- hogs
+- home
+- homeless
+- homes
+- honey
+- horses
+- hospitals
+- hostages
+- housing
+- human
+- hunting
+- impact
+- imports
+- improvement
+- income
+- indemnity
+- indians-education
+- indians-lands
+- insignia
+- inspection
+- international
+- inventions
+- investments
+- iraq
+- juices
+- justice
+- kiwifruit
+- kuwait
+- labeling
+- laboratories
+- lands
+- lawyers
+- lebanon
+- legal
+- lending
+- libraries
+- limes
+- livestock
+- lobbying
+- local
+- low
+- lunch
+- mammals
+- management
+- manpower
+- manufactured
+- mariana
+- marine
+- marital
+- maritime
+- marketing
+- mass
+- maternal
+- measurement
+- meat
+- medical
+- melons
+- migrant
+- military
+- milk
+- mineral
+- miners
+- mines
+- moderate
+- mortgage
+- mortgages
+- motion
+- museums
+- mushrooms
+- national
+- natural
+- navigation
+- nectarines
+- nonprofit
+- northern
+- nuclear
+- nursery
+- nutrition
+- nuts
+- oats
+- oil
+- oils
+- oilseeds
+- olives
+- onions
+- oranges
+- orders
+- pacific
+- packaging
+- parks
+- patents
+- payments
+- peaches
+- peanuts
+- pears
+- personnel
+- pests
+- pets
+- pictures
+- pistachios
+- plains
+- plant
+- plants
+- plums
+- popcorn
+- postal
+- potatoes
+- poultry
+- practices
+- preservation
+- prevention
+- price
+- private
+- procurement
+- products
+- programs-agriculture
+- programs-business
+- programs-communications
+- programs-education
+- programs-energy
+- programs-housing
+- programs-indians
+- programs-natural
+- programs-social
+- property
+- prunes
+- public
+- publications
+- puerto
+- quarantine
+- quotas
+- railroads
+- raisins
+- range
+- rates
+- real
+- reclamation
+- refuges
+- regulations
+- rehabilitation
+- religious
+- rent
+- resources
+- rice
+- rico
+- rights-of-way
+- roads
+- royalties
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- scientific
+- seals
+- secondary
+- securities
+- seeds
+- seismic
+- seizures
+- service
+- services
+- sex
+- sheep
+- signs
+- small
+- social
+- soil
+- soybeans
+- spearmint
+- species
+- stamps
+- standards
+- state
+- statements
+- status
+- stock
+- stockyards
+- straw
+- student
+- students
+- study
+- subjects
+- subsidies
+- sugar
+- supply
+- support
+- surety
+- surplus
+- symbols
+- system
+- tangelos
+- tangerines
+- taxes
+- teachers
+- technical
+- technology
+- telecommunications
+- telephone
+- television
+- territory
+- threatened
+- tobacco
+- tomatoes
+- trade
+- traffic
+- training
+- travel
+- treatment
+- trees
+- trust
+- truth
+- tuberculosis
+- unemployment
+- uniform
+- universities
+- urban
+- utilities
+- vegetables
+- veterans
+- veterinarians
+- virgin
+- vocational
+- volunteers
+- walnuts
+- warehouses
+- waste
+- watermelons
+- watersheds
+- waterways
+- welfare
+- wheat
+- wilderness
+- wildlife
+- women
+- wool
+- youth
 name: Department of Agriculture
 phone: 202-260-2657
 public_liaison:

--- a/contacts/data/USNRC.yaml
+++ b/contacts/data/USNRC.yaml
@@ -113,83 +113,67 @@ departments:
 description: An independent agency, the Nuclear Regulatory Commission regulates commercial
   nuclear power plants and other uses of nuclear materials.
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Advisory committees
-- Aged
-- Airports
-- Alcohol abuse
-- Antitrust
-- Biologics
-- Blind
-- Buildings and facilities
-- Civil rights
-- Claims
-- Classified information
-- Colleges and universities
-- Confidential business information
-- Drug abuse
-- Drug testing
-- Drugs
-- Education
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Employment
-- Environmental protection
-- Equal educational opportunity
-- Equal employment opportunity
-- Exports
-- Federal buildings and facilities
-- Fire prevention
-- Fraud
-- Freedom of information
-- Government contracts
-- Government employees
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-social programs
-- Hazardous materials transportation
-- Hazardous waste
-- Health facilities
-- Health professions
-- Highways and roads
-- Imports
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- Inventions and patents
-- Investigations
-- Labeling
-- Loan programs
-- Manpower training programs
-- Mass transportation
-- Medical devices
-- Nuclear materials
-- Nuclear power plants and reactors
-- Occupational safety and health
-- Organization and functions (Government agencies)
-- Packaging and containers
-- Penalties
-- Privacy
-- Radiation protection
-- Railroads
-- Religious discrimination
-- Reporting and recordkeeping requirements
-- Scientific equipment
-- Security measures
-- Sex discrimination
-- Small businesses
-- Student aid
-- Sunshine Act
-- Uranium
-- Veterans
-- Wages
-- Waste treatment and disposal
-- Whistleblowing
-- Women
+- abuse
+- act
+- advisory
+- aid
+- airports
+- alcohol
+- antitrust
+- biologics
+- blind
+- businesses
+- classified
+- colleges
+- committees
+- confidential
+- containers
+- devices
+- disposal
+- drug
+- drugs
+- equipment
+- exports
+- fire
+- fraud
+- hazardous
+- highways
+- imports
+- inventions
+- labeling
+- manpower
+- mass
+- materials
+- measures
+- medical
+- nuclear
+- occupational
+- packaging
+- patents
+- plants
+- prevention
+- programs-education
+- programs-social
+- radiation
+- railroads
+- reactors
+- religious
+- roads
+- scientific
+- sex
+- small
+- student
+- study
+- sunshine
+- testing
+- training
+- treatment
+- universities
+- uranium
+- veterans
+- waste
+- whistleblowing
+- women
 name: Nuclear Regulatory Commission
 request_time_stats:
   '2008':

--- a/contacts/data/USPS.yaml
+++ b/contacts/data/USPS.yaml
@@ -215,44 +215,32 @@ departments:
 description: The Postal Service provides mail processing and delivery services to
   individuals and businesses in the U.S.
 keywords:
-- Administrative practice and procedure
-- Advertising
-- Air carriers
-- Archives and records
-- Authority delegations (Government agencies)
-- Buildings and facilities
-- Civil rights
-- Claims
-- Classified information
-- Computer technology
-- Conflict of interests
-- Courts
-- Credit
-- Crime
-- Environmental impact statements
-- Equal access to justice
-- Federal buildings and facilities
-- Foreign relations
-- Fraud
-- Freedom of information
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Individuals with disabilities
-- Intergovernmental relations
-- Law enforcement
-- Law enforcement officers
-- Lotteries
-- Maritime carriers
-- Organization and functions (Government agencies)
-- Penalties
-- Postal Service
-- Privacy
-- Security measures
-- Seizures and forfeitures
-- State and local governments
-- Wages
+- access
+- advertising
+- archives
+- authority
+- carriers
+- classified
+- computer
+- courts
+- crime
+- delegations
+- forfeitures
+- fraud
+- governments
+- impact
+- justice
+- local
+- lotteries
+- maritime
+- measures
+- officers
+- postal
+- procurement
+- seizures
+- service
+- state
+- statements
 name: United States Postal Service
 request_time_stats:
   '2010':

--- a/contacts/data/USTR.yaml
+++ b/contacts/data/USTR.yaml
@@ -82,10 +82,8 @@ departments:
 description: Under the Executive Office of the President, the U.S. Trade Representative
   negotiates with foreign governments to craft trade agreements and resolve disputes.
 keywords:
-- Administrative practice and procedure
-- Confidential business information
-- Foreign trade
-- Imports
+- confidential
+- imports
 name: Office of the United States Trade Representative
 request_time_stats:
   '2010':

--- a/contacts/data/VA.yaml
+++ b/contacts/data/VA.yaml
@@ -1751,197 +1751,179 @@ description: For information about VA medical care or benefits, write, call or v
   your nearest VA facility.
 fax: 202-632-7581
 keywords:
-- Accounting
-- Administrative practice and procedure
-- Adult education
-- Aged
-- Agriculture
-- Air traffic controllers
-- Airports
-- Alcohol abuse
-- Alcoholism
-- Alimony
-- American Samoa
-- Antitrust
-- Archives and records
-- Armed forces
-- Asbestos
-- Authority delegations (Government agencies)
-- Blind
-- Broadband
-- Buildings and facilities
-- Business and industry
-- Cemeteries
-- Child support
-- Civil rights
-- Claims
-- Colleges and universities
-- Communications
-- Community development
-- Condominiums
-- Conflict of interests
-- Copyright
-- Courts
-- Credit
-- Crime
-- Cultural exchange programs
-- Day care
-- Defense Department
-- Dental health
-- Disability benefits
-- Drug abuse
-- Education
-- Education of disadvantaged
-- Education of individuals with disabilities
-- Educational facilities
-- Educational research
-- Educational study programs
-- Electric power
-- Electric power rates
-- Electric utilities
-- Elementary and secondary education
-- Employment
-- Equal educational opportunity
-- Equal employment opportunity
-- Estates
-- Federal buildings and facilities
-- Federally affected areas
-- Firefighters
-- Flags
-- Flood insurance
-- Foreign currencies
-- Foreign relations
-- Foreign trade
-- Freedom of information
-- Frozen foods
-- Government contracts
-- Government employees
-- Government procurement
-- Government property
-- Government property management
-- Grant programs
-- Grant programs-education
-- Grant programs-health
-- Grant programs-social programs
-- Grant programs-transportation
-- Grant programs-veterans
-- Guam
-- Health care
-- Health facilities
-- Health insurance
-- Health professions
-- Health records
-- Highways and roads
-- Home improvement
-- Homeless
-- Hospitals
-- Hostages
-- Housing
-- Human research subjects
-- Income taxes
-- Indians
-- Indians-education
-- Indians-lands
-- Individuals with disabilities
-- Insurance
-- Intergovernmental relations
-- International organizations
-- Inventions and patents
-- Investigations
-- Iraq
-- Kuwait
-- Labor
-- Law enforcement officers
-- Lawyers
-- Lebanon
-- Legal services
-- Life insurance
-- Loan programs
-- Loan programs-Indians
-- Loan programs-agriculture
-- Loan programs-communications
-- Loan programs-education
-- Loan programs-energy
-- Loan programs-housing and community development
-- Loan programs-social programs
-- Loan programs-veterans
-- Low and moderate income housing
-- Manpower training programs
-- Manufactured homes
-- Mass transportation
-- Medicaid
-- Medical and dental schools
-- Medical devices
-- Medical research
-- Medicare
-- Mental health programs
-- Migrant labor
-- Military personnel
-- Mortgage insurance
-- Mortgages
-- Nonprofit organizations
-- Northern Mariana Islands
-- Nursing homes
-- Organization and functions (Government agencies)
-- Pacific Islands Trust Territory
-- Parking
-- Penalties
-- Philippines
-- Postal Service
-- Privacy
-- Private schools
-- Public assistance programs
-- Public housing
-- Radioactive materials
-- Railroad retirement
-- Railroad unemployment insurance
-- Railroads
-- Religious discrimination
-- Relocation assistance
-- Rent subsidies
-- Reporting and recordkeeping requirements
-- Research
-- Retirement
-- Rural areas
-- Scholarships and fellowships
-- School construction
-- Schools
-- Science and technology
-- Seals and insignia
-- Securities
-- Security measures
-- Sex discrimination
-- Small businesses
-- Social security
-- State and local governments
-- Student aid
-- Supplemental Security Income (SSI)
-- Surety bonds
-- Taxes
-- Teachers
-- Telecommunications
-- Telephone
-- Transportation
-- Travel
-- Travel and transportation expenses
-- Treaties
-- Trusts and trustees
-- Unemployment compensation
-- Urban areas
-- Utilities
-- Veterans
-- Veterans Affairs Department
-- Vietnam
-- Virgin Islands
-- Vocational education
-- Vocational rehabilitation
-- Wages
-- Waste treatment and disposal
-- Water pollution control
-- Water resources
-- Water supply
-- Watersheds
-- Women
+- abuse
+- adult
+- affairs
+- affected
+- aid
+- airports
+- alcohol
+- alcoholism
+- alimony
+- american
+- antitrust
+- archives
+- armed
+- asbestos
+- authority
+- benefits
+- blind
+- broadband
+- businesses
+- care
+- cemeteries
+- child
+- colleges
+- compensation
+- condominiums
+- construction
+- controllers
+- copyright
+- courts
+- crime
+- cultural
+- currencies
+- day
+- defense
+- delegations
+- dental
+- department
+- devices
+- disability
+- disadvantaged
+- disposal
+- elementary
+- estates
+- exchange
+- expenses
+- federally
+- fellowships
+- firefighters
+- flags
+- flood
+- foods
+- forces
+- frozen
+- governments
+- guam
+- highways
+- home
+- homeless
+- homes
+- hospitals
+- hostages
+- housing
+- human
+- improvement
+- income
+- indians-education
+- indians-lands
+- insignia
+- international
+- inventions
+- iraq
+- kuwait
+- lawyers
+- lebanon
+- legal
+- life
+- local
+- low
+- manpower
+- manufactured
+- mariana
+- mass
+- materials
+- measures
+- medicaid
+- medical
+- medicare
+- mental
+- migrant
+- military
+- moderate
+- mortgage
+- mortgages
+- nonprofit
+- northern
+- nursing
+- officers
+- pacific
+- parking
+- patents
+- personnel
+- philippines
+- postal
+- private
+- procurement
+- programs-agriculture
+- programs-communications
+- programs-education
+- programs-energy
+- programs-indians
+- programs-social
+- programs-transportation
+- programs-veterans
+- public
+- radioactive
+- railroad
+- railroads
+- rates
+- records
+- rehabilitation
+- religious
+- relocation
+- rent
+- retirement
+- roads
+- rural
+- samoa
+- scholarships
+- school
+- schools
+- science
+- seals
+- secondary
+- security
+- service
+- services
+- sex
+- small
+- social
+- ssi
+- state
+- student
+- study
+- subjects
+- subsidies
+- supplemental
+- supply
+- support
+- surety
+- taxes
+- teachers
+- telecommunications
+- telephone
+- territory
+- traffic
+- training
+- travel
+- treaties
+- treatment
+- trust
+- trustees
+- trusts
+- unemployment
+- universities
+- urban
+- utilities
+- veterans
+- vietnam
+- virgin
+- vocational
+- waste
+- watersheds
+- women
 name: Department of Veterans Affairs
 phone: 202-632-7465
 public_liaison:

--- a/contacts/requirements.txt
+++ b/contacts/requirements.txt
@@ -7,3 +7,5 @@ flake8
 mock
 nose
 vcrpy
+stop-words
+numpy

--- a/contacts/tests/clean_keywords_tests.py
+++ b/contacts/tests/clean_keywords_tests.py
@@ -99,11 +99,11 @@ class CleanKeywordsTests(TestCase):
 
     def test_clean_keywords(self):
         """
-        Verify that keywords with scores lower than the median are removed
+        Verify that keywords with scores lower than the threshold are removed
         """
 
         keywords = ['freedom', 'united', 'states', 'information']
-        scores = [1, 2, 3, 4]
+        scores = [0, 0, 1, 4]
         new_keywords = clean_keywords.clean_keywords(keywords, scores)
         self.assertEqual(new_keywords, ['states', 'information'])
 

--- a/contacts/tests/clean_keywords_tests.py
+++ b/contacts/tests/clean_keywords_tests.py
@@ -112,3 +112,53 @@ class CleanKeywordsTests(TestCase):
         scores = [1]
         new_keywords = clean_keywords.clean_keywords(keywords, scores)
         self.assertEqual(new_keywords, keywords)
+
+    def test_extract_agency_keywords(self):
+        """
+        Verify that keywords are transformed into a dict that maps keywords
+        to agencies and a dict that transforms agencies to keywords
+        """
+
+        keywords_agency = {}
+        agency_keywords = {}
+        agency = {'name': 'Agency 1', 'departments': []}
+
+        # Test agency with no keywords
+        clean_keywords.extract_agency_keywords(
+            agency=agency,
+            agency_keywords=agency_keywords,
+            keywords_agency=keywords_agency)
+
+        self.assertEqual(keywords_agency, {})
+        self.assertEqual(agency_keywords, {})
+
+        # Test agency with keywords
+        agency['keywords'] = ['freedom', 'information', 'act']
+        clean_keywords.extract_agency_keywords(
+            agency=agency,
+            agency_keywords=agency_keywords,
+            keywords_agency=keywords_agency)
+
+        self.assertEqual(
+            keywords_agency,
+            {
+                'freedom': ['Agency 1'],
+                'information': ['Agency 1'],
+                'act': ['Agency 1']
+            })
+        self.assertEqual(
+            agency_keywords, {'Agency 1': ['freedom', 'information', 'act']})
+
+        # Test adding another agency that is in departments keywords
+        agency = {'name': 'Agency 2', 'departments': []}
+        agency['departments'] = [
+            {'name': 'Office 1', 'keywords': ['freedom', 'united']}]
+        clean_keywords.extract_agency_keywords(
+            agency=agency,
+            agency_keywords=agency_keywords,
+            keywords_agency=keywords_agency)
+        self.assertTrue('Office 1' in keywords_agency['freedom'])
+        self.assertTrue('Office 1' in keywords_agency['united'])
+        self.assertTrue('united' in agency_keywords['Office 1'])
+        self.assertTrue('freedom' in agency_keywords['Office 1'])
+

--- a/contacts/tests/clean_keywords_tests.py
+++ b/contacts/tests/clean_keywords_tests.py
@@ -105,7 +105,7 @@ class CleanKeywordsTests(TestCase):
         keywords = ['freedom', 'united', 'states', 'information']
         scores = [0, 0, 1, 4]
         new_keywords = clean_keywords.clean_keywords(keywords, scores)
-        self.assertEqual(new_keywords, ['states', 'information'])
+        self.assertEqual(new_keywords, ['information', 'states'])
 
         # Wont' break if there is only one keyword
         keywords = ['freedom']

--- a/contacts/tests/clean_keywords_tests.py
+++ b/contacts/tests/clean_keywords_tests.py
@@ -162,3 +162,37 @@ class CleanKeywordsTests(TestCase):
         self.assertTrue('united' in agency_keywords['Office 1'])
         self.assertTrue('freedom' in agency_keywords['Office 1'])
 
+    def test_apply_tf_idf(self):
+
+        agency = {
+            'name': 'Agency 1',
+            'keywords': ['united', 'freedom', 'states'],
+            'departments': [{
+                'name': 'Office 1',
+                'keywords': ['freedom', 'united', 'information']
+            }]
+        }
+        # Setup
+        keywords = {
+            'united': ['Agency 1', 'Agency 2', 'Agency 3', 'Office 1'],
+            'freedom': ['Agency 1', 'Agency 2', 'Office 1'],
+            'states': ['Agency 1'],
+            'information': ['Office 1']
+        }
+        agencies = {
+            'Agency 1': ['united', 'freedom', 'states'],
+            'Agency 2': ['united', 'freedom'],
+            'Agency 3': ['united'],
+            'Office 1': ['freedom', 'united', 'information']
+        }
+        total_agencies = 4
+
+        data = clean_keywords.apply_tf_idf(
+            agency=agency,
+            agencies=agencies,
+            keywords=keywords,
+            total_agencies=total_agencies
+        )
+
+        self.assertEqual(data['keywords'], ['states'])
+        self.assertEqual(data['departments'][0]['keywords'], ['information'])

--- a/contacts/tests/clean_keywords_tests.py
+++ b/contacts/tests/clean_keywords_tests.py
@@ -1,0 +1,114 @@
+from unittest import TestCase
+
+import clean_keywords
+
+
+class CleanKeywordsTests(TestCase):
+
+    def test_flatten_keywords(self):
+        """ Verify that list items are flattend into a list of words """
+
+        test_list = ['freedom of information', 'Information', '(United)']
+        result = clean_keywords.flatten_keywords(test_list)
+
+        self.assertEqual(len(result), 4)
+        # Phrases broken into words
+        self.assertEqual(result.count('information'), 2)
+        # Stop words removed
+        self.assertEqual(result.count('of'), 0)
+        # Parentheses are removed and words in lowercase
+        self.assertEqual(result.count('united'), 1)
+
+    def test_update_keyword_agency_dict(self):
+        """ Verify that a dictionary of keywords to agencies is updated """
+
+        # Frist run
+        keywords_agency = {}
+        keywords = ['freedom', 'information']
+        agency_name = 'Agency 1'
+        clean_keywords.update_keyword_agency_dict(
+            keywords_agency=keywords_agency,
+            keywords=keywords,
+            agency_name=agency_name)
+        expected_output = {
+            'information': ['Agency 1'],
+            'freedom': ['Agency 1']
+        }
+        self.assertEqual(keywords_agency, expected_output)
+
+        # Second run
+        keywords = ['freedom', 'united']
+        agency_name = 'Agency 2'
+        clean_keywords.update_keyword_agency_dict(
+            keywords_agency=keywords_agency,
+            keywords=keywords,
+            agency_name=agency_name)
+        # Check that new agencies were appended
+        self.assertEqual(keywords_agency['freedom'], ['Agency 1', 'Agency 2'])
+        # Check that new words were added
+        self.assertTrue('united' in keywords_agency)
+
+    def test_get_tf_idf(self):
+        """ Verifty that tfidf is calculated correctly """
+
+        # Setup
+        keywords = {
+            'united': ['Agency 1', 'Agency 2', 'Agency 3'],
+            'freedom': ['Agency 1', 'Agency 2'],
+            'states': ['Agency 1']
+        }
+        agencies = {
+            'Agency 1': ['united', 'freedom', 'states'],
+            'Agency 2': ['united', 'freedom'],
+            'Agency 3': ['united']
+        }
+        total_agencies = 3
+
+        # Testing a words that all agencies have
+        keyword = 'united'
+        agency = 'Agency 1'
+        score_united = clean_keywords.get_tf_idf(
+            keyword=keyword,
+            keywords=keywords,
+            agency=agency,
+            agencies=agencies,
+            total_agencies=total_agencies)
+        self.assertEqual(score_united, 0.0)
+
+        # Testing with a word that only 2 agencies have
+        keyword = 'freedom'
+        agency = 'Agency 1'
+        score_freedom = clean_keywords.get_tf_idf(
+            keyword=keyword,
+            keywords=keywords,
+            agency=agency,
+            agencies=agencies,
+            total_agencies=total_agencies)
+        self.assertTrue(score_freedom > score_united)
+
+        # Testing with a word that only 1 agency has
+        keyword = 'states'
+        agency = 'Agency 1'
+        score_states = clean_keywords.get_tf_idf(
+            keyword=keyword,
+            keywords=keywords,
+            agency=agency,
+            agencies=agencies,
+            total_agencies=total_agencies)
+        self.assertTrue(score_states > score_freedom)
+
+    def test_clean_keywords(self):
+        """
+        Verify that keywords with scores lower than the median are removed
+        """
+
+        keywords = ['freedom', 'united', 'states', 'information']
+        scores = [1, 2, 3, 4]
+        new_keywords = clean_keywords.clean_keywords(keywords, scores)
+        self.assertEqual(new_keywords, ['states', 'information'])
+
+        # Wont' break if there is only one keyword
+        keywords = ['freedom']
+        scores = [1]
+        new_keywords = clean_keywords.clean_keywords(keywords, scores)
+        self.assertEqual(new_keywords, keywords)


### PR DESCRIPTION
This script implements tf-idf to score each agency's keywords by relevance. Currently, this scripts threshold is set to `0.940983` which cuts about 1/3 of the least relevant keywords. 
